### PR TITLE
Fix kafka topic-enforcer crash in continous mode if an exception occurs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 bazel-*
+ij.bazelproject
+.ijwb
+

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/BUILD
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/BUILD
@@ -2,15 +2,7 @@ package(default_visibility = ["//:__subpackages__"])
 
 java_library(
     name = "enforcer",
-    srcs = [
-        "ConfigDrift.java",
-        "ConfiguredTopic.java",
-        "Enforcer.java",
-        "EnforcerMetrics.java",
-        "Main.java",
-        "TopicService.java",
-        "TopicServiceImpl.java",
-    ],
+    srcs = glob(["*.java"]),
     deps = [
         "//3rdparty/jvm/com/beust:jcommander",
         "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/BaseCommand.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/BaseCommand.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2019. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.topic.enforcer;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * All topic enforcement related CLI tools are an extension of {@link BaseCommand}.
+ */
+@Parameters(commandDescription = "Validate config")
+class BaseCommand {
+
+  static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {
+  };
+  static int SUCCESS = 0;
+  static int FAILURE = 1;
+
+  static {
+    MAPPER.registerModule(new ParameterNamesModule());
+  }
+
+  @Parameter(
+      description = "/path/to/a/configuration/file",
+      required = true,
+      converter = CommandConfigConverter.class)
+  private Map<String, Object> cmdConfig = null;
+
+  final Logger LOG = LoggerFactory.getLogger(getClass());
+
+  BaseCommand() {
+    // DO NOT REMOVE, this is needed by jcommander
+  }
+
+  // for testing
+  BaseCommand(Map<String, Object> cmdConfig) {
+    this.cmdConfig = cmdConfig;
+  }
+
+  Map<String, Object> cmdConfig() {
+    Objects.requireNonNull(cmdConfig, "command has not been initialized with config");
+    return cmdConfig;
+  }
+
+  Map<String, Object> kafkaConfig() {
+    return MAPPER.convertValue(cmdConfig().get("kafka"), MAP_TYPE);
+  }
+
+  List<ConfiguredTopic> configuredTopics() {
+    return Arrays.asList(MAPPER.convertValue(cmdConfig().get("topics"), ConfiguredTopic[].class));
+  }
+
+  public int run() {
+    System.out.println("Kafka connection: " + kafkaConfig().get("bootstrap.servers"));
+    System.out.println("Configured topic count: " + configuredTopics().size());
+    System.out.println("Config looks good!");
+    return SUCCESS;
+  }
+
+  /**
+   * An converter that converts yaml config file to a config stored in a java map.
+   */
+  static class CommandConfigConverter implements IStringConverter<Map<String, Object>> {
+    @Override
+    public Map<String, Object> convert(String file) {
+      try {
+        return convert(new FileInputStream(file));
+      } catch (IOException e) {
+        throw new ParameterException("Could not load config from file " + file, e);
+      }
+    }
+
+    Map<String, Object> convert(InputStream is) throws IOException {
+      Map<String, Object> cmdConfig = MAPPER.readValue(is, MAP_TYPE);
+      Objects.requireNonNull(cmdConfig.get("topics"), "Missing topics from config");
+      Objects.requireNonNull(cmdConfig.get("kafka"), "Missing kafka connection settings from config");
+      return cmdConfig;
+    }
+  }
+
+}

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/DumpCommand.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/DumpCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.topic.enforcer;
+
+import com.beust.jcommander.Parameters;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+@Parameters(commandDescription = "Dump existing cluster config on stdout")
+public class DumpCommand extends BaseCommand {
+
+  @Override
+  public int run() {
+    try (AdminClient kafka = KafkaAdminClient.create(kafkaConfig())) {
+      TopicService topicService = new TopicServiceImpl(kafka, true);
+      Collection<ConfiguredTopic> existing = topicService.listExisting(true).values()
+          .stream()
+          .sorted(Comparator.comparing(ConfiguredTopic::getName))
+          .collect(Collectors.toList());
+      System.out.println(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(existing));
+      return SUCCESS;
+    } catch (JsonProcessingException e) {
+      LOG.error("Failed to dump config", e);
+      return FAILURE;
+    }
+  }
+
+}

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/EnforceCommand.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/EnforceCommand.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2019. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.topic.enforcer;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.exporter.HTTPServer;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Supplier;
+
+@Parameters(commandDescription = "Enforce given configuration")
+public class EnforceCommand extends BaseCommand {
+
+  private static final Gauge lastSuccess = Gauge.build()
+      .name("kafka_topic_enforcer_run_last_success_timestamp")
+      .help("Timestamp of last successful run as epoch seconds.")
+      .register();
+  private static final Counter failures = Counter.build()
+      .name("kafka_topic_enforcer_run_failures_total")
+      .help("Total failures so far.")
+      .register();
+  private static final Counter runs = Counter.build()
+      .name("kafka_topic_enforcer_run_total")
+      .help("Total runs so far.")
+      .register();
+
+  @Parameter(
+      names = {"--dryrun", "-d"},
+      description = "do a dry run")
+  private boolean dryrun = false;
+  @Parameter(
+      names = {"--unsafemode"},
+      description = "run in unsafe mode, topic deletion is _only_ allowed in this mode")
+  private boolean unsafemode = false;
+  @Parameter(
+      names = {"--continuous", "-c"},
+      description = "run enforcement continuously")
+  private boolean continuous = false;
+  @Parameter(
+      names = {"--interval", "-i"},
+      description = "run interval for continuous mode in seconds",
+      arity = 1)
+  private int interval = 600;
+
+  EnforceCommand() {
+    // DO NOT REMOVE, this is needed by jcommander
+  }
+
+  // for testing
+  EnforceCommand(Map<String, Object> cmdConfig, boolean continuous, int interval) {
+    super(cmdConfig);
+    this.continuous = continuous;
+    this.interval = interval;
+  }
+
+  @Override
+  public int run() {
+    try (AdminClient kafka = KafkaAdminClient.create(kafkaConfig())) {
+      TopicService topicService = new TopicServiceImpl(kafka, dryrun);
+      Enforcer enforcer = new Enforcer(topicService, configuredTopics(), !unsafemode);
+      return doRun(enforcer, () -> false);
+    }
+  }
+
+  // for testing
+  int doRun(final Enforcer enforcer, final Supplier<Boolean> stopCondition) {
+    LOG.info("Dry run is {}, safe mode is {}", dryrun ? "ON" : "OFF", unsafemode ? "OFF" : "ON");
+
+    if (!continuous) {
+      return runOnceIgnoreError(enforcer);
+    }
+
+    // continuous mode
+    HTTPServer server = null;
+    final int port = (int) cmdConfig().getOrDefault("metricsPort", 8081);
+    try {
+      server = metricServer(port);
+      LOG.info("Started metrics server at port {}", port);
+      while (!stopCondition.get()) {
+        runOnceIgnoreError(enforcer);
+        Thread.sleep(interval * 1000);
+      }
+    } catch (Exception e) {
+      // exception caught here must have come prometheus server or thread interrupt
+      // all other exceptions are swallowed by runOnceIgnoreError routine
+      LOG.error("Unexpected error", e);
+      return FAILURE;
+    } finally {
+      if (server != null) {
+        server.stop();
+      }
+    }
+    return SUCCESS;
+  }
+
+  // for testing
+  HTTPServer metricServer(int port) throws IOException {
+    return new HTTPServer(port, true);
+  }
+
+  private int runOnceIgnoreError(Enforcer enforcer) {
+    try {
+      runs.inc();
+      // Stats should be recorded before enforcement or else we will miss all anomalies
+      enforcer.stats();
+      enforcer.enforceAll();
+      lastSuccess.setToCurrentTime();
+      return SUCCESS;
+    } catch (Exception e) {
+      LOG.error("Enforcer run failed!", e);
+      failures.inc();
+      return FAILURE;
+    }
+  }
+
+}

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/Main.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/Main.java
@@ -6,191 +6,40 @@ package com.tesla.data.topic.enforcer;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import com.beust.jcommander.Parameters;
-import com.beust.jcommander.ParametersDelegate;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.exporter.HTTPServer;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.KafkaAdminClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * The app.
  */
 public class Main {
 
-  private static final Logger LOG = LoggerFactory.getLogger(Enforcer.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
-  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {
-  };
-  private static final String DUMP_CMD = "dump";
-  private static final String ENFORCE_CMD = "enforce";
-  private static final Gauge lastSuccess = Gauge.build()
-      .name("kafka_topic_enforcer_run_last_success_timestamp")
-      .help("Timestamp of last successful run as epoch seconds.")
-      .register();
-  private static final Counter failures = Counter.build()
-      .name("kafka_topic_enforcer_run_failures_total")
-      .help("Total failures so far.")
-      .register();
-  private static final Counter runs = Counter.build()
-      .name("kafka_topic_enforcer_run_total")
-      .help("Total runs so far.")
-      .register();
-
-
-  // Setups jackson magic that uses parameter name information provided by the Java Reflection API,
-  // this lets us define pojos with final fields without jackson property annotation.
-  static {
-    MAPPER.registerModule(new ParameterNamesModule());
-  }
-
   @Parameter(
       names = {"--help", "-h"},
       help = true)
   private boolean help = false;
 
-  private static class CommonCommandParams {
-    @Parameter(
-        description = "/path/to/a/configuration/file",
-        required = true)
-    private String configFile = null;
-  }
+  public static void main(String[] args) {
+    final Map<String, BaseCommand> commands = new HashMap<>();
+    commands.put("validate", new BaseCommand());
+    commands.put("dump", new DumpCommand());
+    commands.put("enforce", new EnforceCommand());
 
-  @Parameters(commandDescription = "Enforce given configuration")
-  private static class EnforceCommand {
-    @Parameter(
-        names = {"--dryrun", "-d"},
-        description = "do a dry run")
-    private boolean dryrun = false;
-
-    @Parameter(
-        names = {"--unsafemode"},
-        description = "run in unsafe mode, topic deletion is _only_ allowed in this mode")
-    private boolean unsafemode = false;
-
-    @Parameter(
-        names = {"--continuous", "-c"},
-        description = "run enforcement continuously")
-    private boolean continuous = false;
-
-    @Parameter(
-        names = {"--interval", "-i"},
-        description = "run interval for continuous mode in seconds",
-        arity = 1)
-    private int interval = 600;
-
-    @ParametersDelegate
-    private CommonCommandParams common = new CommonCommandParams();
-  }
-
-  @Parameters(commandDescription = "Dump existing cluster config on stdout")
-  private static class DumpCommand {
-    @ParametersDelegate
-    private CommonCommandParams common = new CommonCommandParams();
-  }
-
-  private final DumpCommand dumpCmd = new DumpCommand();
-  private final EnforceCommand enforceCmd = new EnforceCommand();
-
-  public static void main(String[] args) throws Exception {
-    Main main = new Main();
-    JCommander commander = JCommander.newBuilder()
-        .addObject(main)
-        .addCommand(DUMP_CMD, main.dumpCmd)
-        .addCommand(ENFORCE_CMD, main.enforceCmd)
-        .build();
+    final Main main = new Main();
+    final JCommander commander = new JCommander(main);
+    for (Map.Entry<String, BaseCommand> entry : commands.entrySet()) {
+      commander.addCommand(entry.getKey(), entry.getValue());
+    }
     commander.parse(args);
 
     if (main.help || args.length == 0) {
       commander.usage();
-      return;
+      System.exit(BaseCommand.FAILURE);
     }
 
-    String configFile = main.dumpCmd.common.configFile != null ?
-            main.dumpCmd.common.configFile : main.enforceCmd.common.configFile;
-    Map<String, Object> config = loadConfig(new FileInputStream(new File(configFile)));
-    Map<String, Object> kafkaProperties = MAPPER.convertValue(config.get("kafka"), MAP_TYPE);
-    try (AdminClient adminClient = KafkaAdminClient.create(kafkaProperties)) {
-      main.run(commander.getParsedCommand(), adminClient, config);
-    }
-  }
-
-  void run(String command, AdminClient kafka, Map<String, Object> config) throws Exception {
-    TopicService topicService;
-    switch (command) {
-      case DUMP_CMD:
-        topicService = new TopicServiceImpl(kafka, true);
-        Collection<ConfiguredTopic> existing = topicService.listExisting(true).values()
-            .stream()
-            .sorted(Comparator.comparing(ConfiguredTopic::getName))
-            .collect(Collectors.toList());
-        System.out.println(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(existing));
-        break;
-      case ENFORCE_CMD:
-        LOG.info("Dry run is {}, safe mode is {}",
-            enforceCmd.dryrun ? "ON" : "OFF", enforceCmd.unsafemode ? "OFF" : "ON");
-        topicService = new TopicServiceImpl(kafka, enforceCmd.dryrun);
-        Enforcer enforcer = new Enforcer(topicService, topicsFromConf(config), !enforceCmd.unsafemode);
-        if (!enforceCmd.continuous) {
-          enforcer.enforceAll();
-        } else {
-          HTTPServer metricServer = null;
-          try {
-            int port = (int) config.getOrDefault("metricsPort", 8081);
-            metricServer = new HTTPServer(port);
-            LOG.info("Started metrics server at port {}", port);
-            while (true) {
-              // Stats should be recorded before enforcement or else we will miss all anomalies
-              runs.inc();
-              enforcer.stats();
-              enforcer.enforceAll();
-              lastSuccess.setToCurrentTime();
-              Thread.sleep(enforceCmd.interval * 1000);
-            }
-          } catch (Exception e) {
-            LOG.info("Enforcer run failed!", e);
-            failures.inc();
-          } finally {
-            if (metricServer != null) {
-              metricServer.stop();
-            }
-          }
-        }
-        break;
-
-      default:
-        throw new IllegalStateException("Unknown command: " + command);
-    }
-  }
-
-  static List<ConfiguredTopic> topicsFromConf(Map<String, Object> config) {
-    return Arrays.asList(MAPPER.convertValue(config.get("topics"), ConfiguredTopic[].class));
-  }
-
-  static Map<String, Object> loadConfig(InputStream is) throws IOException {
-    Map<String, Object> config = MAPPER.readValue(is, MAP_TYPE);
-    Objects.requireNonNull(config.get("topics"), "Missing topics from config");
-    Objects.requireNonNull(config.get("kafka"), "Missing kafka connection settings from config");
-    return config;
+    final String cmd = commander.getParsedCommand();
+    System.exit(commands.get(cmd).run());
   }
 
 }

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/BUILD
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/BUILD
@@ -1,9 +1,22 @@
 java_test(
-    name = "MainTest",
+    name = "CommandTest",
     srcs = [
-        "MainTest.java",
+        "CommandTest.java",
     ],
     deps = [
+        "//3rdparty/jvm/org/mockito:mockito_core",
+        "//kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer",
+    ],
+)
+
+java_test(
+    name = "EnforceCommandTest",
+    srcs = [
+        "EnforceCommandTest.java",
+    ],
+    deps = [
+        "//3rdparty/jvm/ch/qos/logback:logback_classic",
+        "//3rdparty/jvm/io/prometheus:simpleclient_httpserver",
         "//3rdparty/jvm/org/mockito:mockito_core",
         "//kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer",
     ],

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/EnforceCommandTest.java
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/EnforceCommandTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2019. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.topic.enforcer;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.tesla.data.topic.enforcer.BaseCommand.CommandConfigConverter;
+
+import io.prometheus.client.exporter.HTTPServer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class EnforceCommandTest {
+
+  private String testConf = "---\n" +
+      "kafka:\n" +
+      "    bootstrap.servers: localhost:9092\n" +
+      "\n" +
+      "topics:\n" +
+      "    - name: topic_a\n" +
+      "      partitions: 1\n" +
+      "      replicationFactor: 1";
+
+  private CommandConfigConverter converter = new CommandConfigConverter();
+
+  private Enforcer enforcer;
+  private HTTPServer metricServer;
+
+  private Map<String, Object> config;
+
+  @Before
+  public void setup() throws IOException {
+    config = converter.convert(
+        new ByteArrayInputStream(testConf.getBytes(Charset.forName("UTF-8"))));
+    config.put("metricsPort", findFreePort());
+    enforcer = mock(Enforcer.class);
+    metricServer = mock(HTTPServer.class);
+  }
+
+  private static int findFreePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      socket.setReuseAddress(true);
+      return socket.getLocalPort();
+    }
+  }
+
+  private void check(final EnforceCommand command, final int count) {
+    Supplier<Boolean> stop = new Supplier<Boolean>() {
+      private int runs = 0;
+
+      @Override
+      public Boolean get() {
+        return ++runs > count;
+      }
+    };
+    command.doRun(enforcer, stop);
+    verify(enforcer, times(count)).stats();
+    verify(enforcer, times(count)).enforceAll();
+    verifyNoMoreInteractions(enforcer);
+  }
+
+  @Test
+  public void testNotContinuousMode() {
+    EnforceCommand command = new EnforceCommand(config, false, 0);
+    check(command, 1);
+  }
+
+  @Test
+  public void testContinuousModeHappy() {
+    EnforceCommand command = new EnforceCommand(config, true, 0);
+    check(command, 2);
+  }
+
+  @Test
+  public void testContinuousModeFailure() {
+    // first run fails
+    doThrow(new RuntimeException("failed")).doNothing().when(enforcer).enforceAll();
+    EnforceCommand command = new EnforceCommand(config, true, 0);
+    check(command, 2);
+  }
+
+  @Test
+  public void testMetricServer() throws IOException {
+    EnforceCommand command = spy(new EnforceCommand(config, true, 0));
+    doReturn(metricServer).when(command).metricServer(anyInt());
+    check(command, 1);
+    verify(metricServer).stop();
+    verifyNoMoreInteractions(metricServer);
+  }
+
+  @Test
+  public void testNoMetricServer() throws IOException {
+    EnforceCommand command = spy(new EnforceCommand(config, false, 0));
+    verify(command, never()).metricServer(anyInt());
+  }
+
+  @Test
+  public void testAbortIfMetricServerFails() throws IOException {
+    EnforceCommand command = spy(new EnforceCommand(config, true, 0));
+    doThrow(new IOException("failed")).when(command).metricServer(anyInt());
+    check(command, 0);
+    verify(command).metricServer(anyInt());
+  }
+
+}


### PR DESCRIPTION
Prior to this change, topic-enforcer would crash if an error is encountered
in one of the runs in continous mode. Thats not what we want, the expected
ux is to track the error but continue to be alive and maintain continous
enforcement.

To improve testing, this change refactors cli layers.