### PR TITLE
Honor unsafe mode in partition increase & config update flow

### DIFF
--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/BUILD
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/BUILD
@@ -40,6 +40,7 @@ java_test(
         "EnforcerTest.java",
     ],
     deps = [
+        "//3rdparty/jvm/ch/qos/logback:logback_classic",
         "//3rdparty/jvm/org/mockito:mockito_core",
         "//kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer",
     ],


### PR DESCRIPTION
Prior to this change unsafe flag only affected topic deletion behavior, this
change ensures that we make the behavior consistent across all kinds of changes
(a) partition increase (b) config update (c) topic deletion

This change also improves logging, for instance if an unsafe drift was detected
while operating in safe mode -- enforcer wouldn't report it in the logs --
very bad ux. This change reports all drifts regardless of the operating mode.