### PR TITLE
Add metric to track when we get an exception on querying Kafka

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -226,6 +226,7 @@ public class ConsumerFreshness {
 
             @Override
             public void onFailure(Throwable throwable) {
+              metrics.error.labels(client.getCluster(), consumerGroup);
               workers.add(worker);
             }
           }, this.executor);

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
@@ -36,6 +36,11 @@ public class FreshnessMetrics {
       .help("Number of offsets that loaded from Kafka but were found to be invalid (producer sent invalid timestamp?)")
       .labelNames("cluster", "consumer")
       .create();
+  Counter error = new Counter.Builder()
+      .name("kafka_consumer_freshness_runtime_query_exception")
+      .help("Number of Kafka queries that threw an exception")
+      .labelNames("cluster", "consumer")
+      .create();
   Counter burrowClustersReadFailed = new Counter.Builder()
       .name("kafka_consumer_freshness_runtime_failed_burrow_clusters_read")
       .help("Number of times we failed to lookup the clusters from burrow")
@@ -55,7 +60,7 @@ public class FreshnessMetrics {
 
   public void register() {
     for (SimpleCollector collector :
-        newArrayList(elapsed, missing, kafkaRead, failed, invalid, freshness, kafkaQueryLatency)) {
+        newArrayList(elapsed, missing, kafkaRead, failed, invalid, error, freshness, kafkaQueryLatency)) {
       collector.register();
     }
   }


### PR DESCRIPTION
Useful for understanding when a cluster becomes misconfigured or unreachable (e.g. goes down)