### PR TITLE
Making kafka_certificates lib and KafkaClientKeystores#writeStores public

### DIFF
--- a/kafka_certificates/src/main/java/com/tesla/data/certificates/keystore/BUILD
+++ b/kafka_certificates/src/main/java/com/tesla/data/certificates/keystore/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "keystore",

--- a/kafka_certificates/src/main/java/com/tesla/data/certificates/keystore/KafkaClientKeystores.java
+++ b/kafka_certificates/src/main/java/com/tesla/data/certificates/keystore/KafkaClientKeystores.java
@@ -125,7 +125,7 @@ public class KafkaClientKeystores {
    * @param store keystore to write
    * @return the bytes of the keystore
    */
-  private byte[] writeStore(Optional<String> directory, String type, KeyStore store) throws IOException,
+  public byte[] writeStore(Optional<String> directory, String type, KeyStore store) throws IOException,
       CertificateException,
       NoSuchAlgorithmException, KeyStoreException {
     try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {


### PR DESCRIPTION
So the library can be used outside of just a command-line tool