### PR TITLE
Keystore as-a-library usability improvements

### DIFF
--- a/kafka_certificates/src/main/java/com/tesla/data/certificates/keystore/KeystoreConfig.java
+++ b/kafka_certificates/src/main/java/com/tesla/data/certificates/keystore/KeystoreConfig.java
@@ -1,5 +1,8 @@
 package com.tesla.data.certificates.keystore;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.beust.jcommander.Parameter;
 
 import java.io.File;
@@ -9,17 +12,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Base64;
+import java.util.Optional;
 
 public class KeystoreConfig {
-  private static final int COPY_BUF_SIZE = 8024;
-
   @Parameter(names = "--certificate", description = "Path to the client's signed certificate", required = true)
   String certificate;
 
   @Parameter(names = "--key", description = "Path to the client's private key", required = true)
   String key;
 
-  @Parameter(names = "--issuing_ca", description = "Path to the  certificate for the issuing CA", required = true)
+  @Parameter(names = "--issuing_ca", description = "Path to the certificate for the issuing CA. If not specified, uses " +
+      "the first certificate in the CA Chain")
   String issuingCa;
 
   @Parameter(names = "--ca_chain", description = "Path to the  certificate chain", required = true)
@@ -38,19 +41,19 @@ public class KeystoreConfig {
   private byte[] keystore;
   private byte[] truststore;
 
-  public InputStream key() throws FileNotFoundException {
+  public InputStream key() throws IOException {
     return new FileInputStream(key);
   }
 
-  public InputStream certificate() throws FileNotFoundException {
+  public InputStream certificate() throws IOException {
     return new FileInputStream(certificate);
   }
 
-  public InputStream issuingCa() throws FileNotFoundException {
-    return new FileInputStream(issuingCa);
+  public Optional<InputStream> issuingCa() throws IOException {
+    return issuingCa == null? empty(): of(new FileInputStream(issuingCa));
   }
 
-  public InputStream caChain() throws FileNotFoundException {
+  public InputStream caChain() throws IOException {
     return new FileInputStream(caChain);
   }
 

--- a/kafka_certificates/src/test/java/com/tesla/data/certificates/keystore/KafkaClientKeystoresTest.java
+++ b/kafka_certificates/src/test/java/com/tesla/data/certificates/keystore/KafkaClientKeystoresTest.java
@@ -1,25 +1,34 @@
 package com.tesla.data.certificates.keystore;
 
+import static com.tesla.data.certificates.keystore.KafkaClientKeystores.certFactory;
+import static com.tesla.data.certificates.keystore.KafkaClientKeystores.readCertificateChain;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.junit.Test;
 import com.google.common.io.Resources;
+import org.junit.Test;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Optional;
 
 public class KafkaClientKeystoresTest {
 
   private static final String PASSWORD = "password";
+  private static final String ISSUER_CN = "C=US,O=Tesla\\, Inc.,OU=PKI,CN=Corporate NA Device Issuing CA 01";
+  private static final String ROOT_CN = "C=US,O=Tesla\\, Inc.,OU=PKI,CN=Corporate Root CA";
 
   @Test
   public void testKeystore() throws Exception {
-    InputStream key = Resources.getResource("keystore/client.key").openStream();
-    InputStream cert = Resources.getResource("keystore/client.crt").openStream();
-    InputStream caChain = Resources.getResource("keystore/ca_chain").openStream();
+    InputStream key = stream("client.key");
+    InputStream cert = stream("client.crt");
+    InputStream caChain = stream("ca_chain");
 
     KafkaClientKeystores keystores = new KafkaClientKeystores(PASSWORD);
     KeyStore store = keystores.createKeystore(key, cert, caChain);
@@ -29,13 +38,69 @@ public class KafkaClientKeystoresTest {
     // should be our cert + ca chain (which we know is two certs long)
     Certificate[] chain = store.getCertificateChain("client");
     assertEquals(3, chain.length);
+    assertCertificateSubjectName(chain[1], ISSUER_CN);
+    assertCertificateSubjectName(chain[2], ROOT_CN);
   }
 
   @Test
   public void testTruststore() throws Exception {
     KafkaClientKeystores keystores = new KafkaClientKeystores(PASSWORD);
-    InputStream ca = Resources.getResource("keystore/issuing_ca").openStream();
-    KeyStore store = keystores.createTruststore(ca);
-    assertNotNull(store.getCertificate("caroot"));
+    InputStream ca = stream("issuing_ca");
+    KeyStore store = keystores.createTruststore(readCertificateChain(certFactory, ca).get(0));
+    assertCertificateSubjectName(store.getCertificate("caroot"), ISSUER_CN);
+  }
+
+  @Test
+  public void testTruststoreFromConfig() throws Exception {
+    KafkaClientKeystores keystores = new KafkaClientKeystores(PASSWORD);
+    KeyStore store = keystores.createTruststore(new ResourceStreamConfig());
+    assertCertificateSubjectName(store.getCertificate("caroot"), ISSUER_CN);
+  }
+
+  /**
+   * When there is no issuing CA, it should use the certificate in the certificate chain
+   * @throws Exception
+   */
+  @Test
+  public void testTruststoreFromConfigWithEmptyIssuingCa() throws Exception {
+    KafkaClientKeystores keystores = new KafkaClientKeystores(PASSWORD);
+    KeyStore store = keystores.createTruststore(new ResourceStreamConfig(){
+      @Override
+      public Optional<InputStream> issuingCa() {
+        return empty();
+      }
+    });
+    assertCertificateSubjectName(store.getCertificate("caroot"), ISSUER_CN);
+  }
+
+  private void assertCertificateSubjectName(Certificate cert, String name){
+    assertEquals(name, ((X509Certificate)cert).getSubjectDN().getName());
+  }
+
+  private static class ResourceStreamConfig extends KeystoreConfig {
+
+    @Override
+    public InputStream key() throws IOException {
+      return stream("client.key");
+    }
+
+    @Override
+    public InputStream certificate() throws IOException {
+      return stream("client.cert");
+    }
+
+    @Override
+    public Optional<InputStream> issuingCa() throws IOException {
+      return of(stream("issuing_ca"));
+    }
+
+    @Override
+    public InputStream caChain() throws IOException {
+      return stream("ca_chain");
+    }
+  }
+
+  private static InputStream stream(String file) throws IOException {
+    return Resources.getResource("keystore/"+file).openStream();
   }
 }


### PR DESCRIPTION
Rather than making sure you pass in the right certificates to the input
streams, now you just pass in an instance of KeystoreConfig and it does
the right thing for you when creating the keystore or truststore. However,
also allows access to underlying methods to make the stores yourself, if
you prefer.

Also, adds support for reading the Issuing CA certificate from the CA Chain,
rather than having a separate certificate. This is a common way certificates
are handed out to clients, so also improves usability dramatically (rather
than messing with manually editing certs).