### PR TITLE
Add support for tagging a configured topic

### DIFF
--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/ConfiguredTopic.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/ConfiguredTopic.java
@@ -23,6 +23,10 @@ public class ConfiguredTopic {
   private final short replicationFactor;
   private final Map<String, String> config;
 
+  // Only meant for cosmetic labeling of a topic in the enforcer config, its not passed to the
+  // brokers
+  private Map<String, Object> tags = new HashMap<>();
+
   public ConfiguredTopic(String name, int partitions,
                          short replicationFactor, Map<String, String> config) {
     this.name = checkNotNull(name, "topic name should be non null");
@@ -50,6 +54,16 @@ public class ConfiguredTopic {
     return config;
   }
 
+  public Map<String, Object> getTags() {
+    return tags;
+  }
+
+  // Unlike the mandatory fields, optional fields needs a setter
+  // see https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names
+  public void setTags(Map<String, Object> tags) {
+    this.tags = tags;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -57,6 +71,7 @@ public class ConfiguredTopic {
         .add("partitions", partitions)
         .add("replicationFactor", replicationFactor)
         .add("config", config)
+        .add("tags", tags)
         .toString();
   }
 

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/DumpCommand.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/DumpCommand.java
@@ -13,7 +13,9 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.stream.Collectors;
 
-@Parameters(commandDescription = "Dump existing cluster config on stdout")
+@Parameters(commandDescription = "Dump existing cluster config on stdout. " +
+    "A subset of topic config is not serialized on the server side and that would be missing in " +
+    "the dump output, example: topic tags.")
 public class DumpCommand extends BaseCommand {
 
   @Override

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/CommandTest.java
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/CommandTest.java
@@ -13,25 +13,32 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 public class CommandTest {
 
-  private String testConf = "---\n" +
-      "kafka:\n" +
-      "    bootstrap.servers: localhost:9092\n" +
-      "\n" +
-      "topics:\n" +
-      "    - name: topic_a\n" +
-      "      partitions: 1\n" +
-      "      replicationFactor: 1\n" +
-      "      config:\n" +
-      "          retention.ms: 604800000\n" +
-      "          compression.type: gzip\n" +
-      "    - name: topic_b\n" +
-      "      partitions: 1\n" +
-      "      replicationFactor: 1";
+  private String testConf =
+      "---\n"
+          + "kafka:\n"
+          + "    bootstrap.servers: localhost:9092\n"
+          + "\n"
+          + "topics:\n"
+          + "    - name: topic_a\n"
+          + "      partitions: 1\n"
+          + "      replicationFactor: 1\n"
+          + "      config:\n"
+          + "          retention.ms: 604800000\n"
+          + "          compression.type: gzip\n"
+          + "      tags:\n"
+          + "          owner: team@company.com\n"
+          + "          datasets:\n"
+          + "             - root.domain.product.data.type-one\n"
+          + "             - root.domain.product.data.type-two\n"
+          + "    - name: topic_b\n"
+          + "      partitions: 1\n"
+          + "      replicationFactor: 1";
 
   private CommandConfigConverter converter = new CommandConfigConverter();
 
@@ -55,18 +62,22 @@ public class CommandTest {
     Assert.assertEquals(1, configuredTopics.get(0).getPartitions());
     Assert.assertEquals(1, configuredTopics.get(0).getReplicationFactor());
     Assert.assertEquals("gzip", configuredTopics.get(0).getConfig().get("compression.type"));
+    Assert.assertEquals("team@company.com", configuredTopics.get(0).getTags().get("owner"));
+    Assert.assertEquals(
+        Arrays.asList("root.domain.product.data.type-one", "root.domain.product.data.type-two"),
+        configuredTopics.get(0).getTags().get("datasets"));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testConfiguredTopicsBad() throws IOException {
-    String badConf = "---\n" +
-        "kafka:\n" +
-        "  bootstrap.servers: localhost:9092\n" +
-        "topics:\n" +
-        "  - name: topic_a    \n" +
-        "    replicationFactor: 1";
+    String badConf =
+        "---\n"
+            + "kafka:\n"
+            + "  bootstrap.servers: localhost:9092\n"
+            + "topics:\n"
+            + "  - name: topic_a    \n"
+            + "    replicationFactor: 1";
     Map<String, Object> config = converter.convert(confStream(badConf));
     new BaseCommand(config).configuredTopics();
   }
-
 }


### PR DESCRIPTION
Tags are a list of (un-restricted) key value pairs that can be associated
with a topic through the enforcer config. They are purely cosmetic at
the moment and not serialized on the broker side -- i.e. a configured
topic de-serialized via admin API would be missing tags.