### PR TITLE
Add a utility class for parsing multi cluster topic config

### DIFF
--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/ClusterTopics.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/ClusterTopics.java
@@ -58,14 +58,14 @@ public class ClusterTopics {
   public static final String CLUSTERS = "clusters";
 
   /**
-   * Get topics configured for a given cluster.
+   * Get topics configurations for a given cluster.
    *
    * @param allTopics a list containing all consolidated (all clusters) topic configurations
    * @param cluster   the name of the cluster to filter topics on
    * @return a list of topics configurations for the given cluster
    * @throws IllegalArgumentException if invalid config structure is passed
    */
-  public static List<Map<String, Object>> topicsForCluster(
+  public static List<Map<String, Object>> topicConfigsForCluster(
       List<Map<String, Object>> allTopics, String cluster) {
     Map<String, List<Map<String, Object>>> map = new HashMap<>();
     allTopics.forEach(
@@ -99,6 +99,7 @@ public class ClusterTopics {
     return map.getOrDefault(cluster, Collections.emptyList());
   }
 
+  // override all properties
   private static Map<String, Object> applyOverrides(
       Map<String, Object> base, Map<String, Object> overrides) {
     Map<String, Object> result = new HashMap<>(base);
@@ -106,12 +107,13 @@ public class ClusterTopics {
     properties.forEach(
         p -> {
           Object newValue = overrides.containsKey(p) ? overrides.get(p) : base.get(p);
-          result.merge(p, newValue, ClusterTopics::applyOverride);
+          result.merge(p, newValue, ClusterTopics::remap);
         });
     return result;
   }
 
-  private static Object applyOverride(Object originalValue, Object overrideValue) {
+  // override a single property
+  private static Object remap(Object originalValue, Object overrideValue) {
     if (originalValue instanceof Map) {
       checkArgument(overrideValue instanceof Map);
       ((Map) originalValue).putAll((Map) overrideValue);

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/ClusterTopics.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/ClusterTopics.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.topic.enforcer;
+
+import static tesla.shade.com.google.common.base.Preconditions.checkArgument;
+
+import tesla.shade.com.google.common.collect.Sets;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A utility class to parse consolidated (multi-cluster) topic configurations. The structure of a consolidated config
+ * is,
+ *
+ * <pre>{@code
+ * ---
+ * clusters:
+ *   foo:
+ *       bootstrap.servers: 'foo_1:9092,foo_2:9092,foo_3:9092'
+ *   bar:
+ *       bootstrap.servers: 'bar_1:9092,bar_2:9092,bar_3:9092'
+ * topics:
+ *   - name: topic_A
+ *     partitions: 30
+ *     replicationFactor: 3
+ *     clusters:
+ *       foo: {}
+ *       bar:
+ *         replicationFactor: 2
+ *   - name: topic_B
+ *     partitions: 10
+ *     replicationFactor: 3
+ *     clusters:
+ *       foo: {}
+ *
+ * ---
+ *
+ * }</pre>
+ *
+ * Rules for filtering topics & applying cluster overrides to the base config are,
+ *
+ * <ul>
+ * <li>A topic is applicable to a cluster if that cluster is present under topic's 'clusters'
+ * attribute. If no changes to base config are desired, specify empty dict '{}'
+ * <li>All topic properties can be overridden, except name
+ * <li>Map (dictionary) properties are merged in way that preserves base settings
+ * </ul>
+ */
+public class ClusterTopics {
+
+  public static final String CLUSTERS = "clusters";
+
+  /**
+   * Get topics configured for a given cluster.
+   *
+   * @param allTopics a list containing all consolidated (all clusters) topic configurations
+   * @param cluster   the name of the cluster to filter topics on
+   * @return a list of topics configurations for the given cluster
+   * @throws IllegalArgumentException if invalid config structure is passed
+   */
+  public static List<Map<String, Object>> topicsForCluster(
+      List<Map<String, Object>> allTopics, String cluster) {
+    Map<String, List<Map<String, Object>>> map = new HashMap<>();
+    allTopics.forEach(
+        tc -> {
+          /*
+          expected structure for a topic configuration 'tc' is:
+          {
+            name: some_topic
+            partitions: 10
+            replicationFactor: 3
+            clusters:
+              foo: {}
+              bar:
+                replicationFactor: 2
+          }
+          */
+          checkArgument(tc.containsKey(CLUSTERS), "%s does not contain cluster overrides", tc);
+          Map<String, Map<String, Object>> clusters =
+              (Map<String, Map<String, Object>>) tc.get(CLUSTERS);
+
+          // base configuration is everything except the overrides under 'clusters' key
+          Map<String, Object> baseConfig = new HashMap<>(tc);
+          baseConfig.remove(CLUSTERS);
+
+          clusters.forEach(
+              (c, o) ->
+                  map.computeIfAbsent(c, k -> new LinkedList<>())
+                      .add(applyOverrides(baseConfig, o)));
+        });
+
+    return map.getOrDefault(cluster, Collections.emptyList());
+  }
+
+  private static Map<String, Object> applyOverrides(
+      Map<String, Object> base, Map<String, Object> overrides) {
+    Map<String, Object> result = new HashMap<>(base);
+    Set<String> properties = Sets.union(base.keySet(), overrides.keySet());
+    properties.forEach(
+        p -> {
+          Object newValue = overrides.containsKey(p) ? overrides.get(p) : base.get(p);
+          result.merge(p, newValue, ClusterTopics::applyOverride);
+        });
+    return result;
+  }
+
+  private static Object applyOverride(Object originalValue, Object overrideValue) {
+    if (originalValue instanceof Map) {
+      checkArgument(overrideValue instanceof Map);
+      ((Map) originalValue).putAll((Map) overrideValue);
+      return originalValue;
+    }
+    return overrideValue;
+  }
+}

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/BUILD
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/BUILD
@@ -55,3 +55,16 @@ java_test(
         "//kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer",
     ],
 )
+
+java_test(
+    name = "ClusterTopicsTest",
+    srcs = [
+        "ClusterTopicsTest.java",
+    ],
+    deps = [
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_databind",
+        "//3rdparty/jvm/com/fasterxml/jackson/dataformat:jackson_dataformat_yaml",
+        "//kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer",
+    ],
+)

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/ClusterTopicsTest.java
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/ClusterTopicsTest.java
@@ -80,7 +80,7 @@ public class ClusterTopicsTest {
           });
 
   static List<Map<String, Object>> topics(String conf, String cluster) throws IOException {
-    return ClusterTopics.topicsForCluster(mapper.readValue(conf, type), cluster);
+    return ClusterTopics.topicConfigsForCluster(mapper.readValue(conf, type), cluster);
   }
 
   @Test
@@ -100,4 +100,36 @@ public class ClusterTopicsTest {
   public void testExclusiveOverridesArePreserved() throws IOException {
     Assert.assertEquals(mapper.readValue(clusterThreeFinal, type), topics(conf, "cluster_three"));
   }
+
+  @Test
+  public void testMapPropertiesAreOverridden() throws IOException {
+    String conf = String.join(
+        "\n",
+        new String[]{
+            "---",
+            "- name: topic_a",
+            "  partitions: 1",
+            "  replicationFactor: 1",
+            "  config: ",
+            "    k1: v1",
+            "    k2: v2",
+            "  clusters:",
+            "    cluster: ",
+            "      config: ",
+            "        k2: v2.1",
+        });
+    String clusterFinal = String.join(
+        "\n",
+        new String[]{
+            "---",
+            "- name: topic_a",
+            "  partitions: 1",
+            "  replicationFactor: 1",
+            "  config: ",
+            "    k1: v1",
+            "    k2: v2.1"
+        });
+    Assert.assertEquals(mapper.readValue(clusterFinal, type), topics(conf, "cluster"));
+  }
+
 }

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/ClusterTopicsTest.java
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/ClusterTopicsTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.topic.enforcer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ClusterTopicsTest {
+
+  private static ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+  private static TypeReference<List<Map<String, Object>>> type =
+      new TypeReference<List<Map<String, Object>>>() {
+      };
+
+  private String conf =
+      String.join(
+          "\n",
+          new String[]{
+              "---",
+              "- name: topic_a",
+              "  partitions: 1",
+              "  replicationFactor: 1",
+              "  clusters:",
+              "      cluster_one: {}",
+              "      cluster_two: ",
+              "        replicationFactor: 2",
+              "- name: topic_b",
+              "  partitions: 1",
+              "  replicationFactor: 1",
+              "  clusters:",
+              "      cluster_three: ",
+              "        config: ",
+              "          k1: v1",
+              "      cluster_two: {}",
+          });
+
+  private String clusterOneFinal =
+      String.join(
+          "\n",
+          new String[]{
+              "---",
+              "- name: topic_a",
+              "  partitions: 1",
+              "  replicationFactor: 1"
+          });
+
+  private String clusterTwoFinal =
+      String.join(
+          "\n",
+          new String[]{
+              "---",
+              "- name: topic_a",
+              "  partitions: 1",
+              "  replicationFactor: 2",
+              "- name: topic_b",
+              "  partitions: 1",
+              "  replicationFactor: 1",
+          });
+
+  private String clusterThreeFinal =
+      String.join(
+          "\n",
+          new String[]{
+              "---",
+              "- name: topic_b",
+              "  partitions: 1",
+              "  replicationFactor: 1",
+              "  config: ",
+              "    k1: v1"
+          });
+
+  static List<Map<String, Object>> topics(String conf, String cluster) throws IOException {
+    return ClusterTopics.topicsForCluster(mapper.readValue(conf, type), cluster);
+  }
+
+  @Test
+  public void testTopicsForCluster() throws IOException {
+    Assert.assertEquals(mapper.readValue(clusterOneFinal, type), topics(conf, "cluster_one"));
+    Assert.assertEquals(Collections.emptyList(), topics(conf, "cluster_four"));
+    Assert.assertEquals(1, topics(conf, "cluster_three").size());
+    Assert.assertEquals(2, topics(conf, "cluster_two").size());
+  }
+
+  @Test
+  public void testNonMapPropertiesAreOverridden() throws IOException {
+    Assert.assertEquals(mapper.readValue(clusterTwoFinal, type), topics(conf, "cluster_two"));
+  }
+
+  @Test
+  public void testExclusiveOverridesArePreserved() throws IOException {
+    Assert.assertEquals(mapper.readValue(clusterThreeFinal, type), topics(conf, "cluster_three"));
+  }
+}


### PR DESCRIPTION
Motivation:

Kafka topic enforcer accepts a config file that is tied to a cluster. This
means you could have N config files for N clusters. Generally, there is a lot of
overlap in these configs, for instance, production and staging configs only
differ in properties such as partition count, replication factor, etc.

It'd be operationally simple and less error-prone to reduce the number
of configs, this change is a step in that direction.