### PR TITLE
Abstract Enforcer in a re-usable library

### DIFF
--- a/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/BUILD
+++ b/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/BUILD
@@ -1,0 +1,19 @@
+package(default_visibility = ["//:__subpackages__"])
+
+java_library(
+    name = "enforcer",
+    srcs = glob(["*.java"]),
+    deps = [
+        "//3rdparty/jvm/com/beust:jcommander",
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_annotations",
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_databind",
+        "//3rdparty/jvm/com/fasterxml/jackson/dataformat:jackson_dataformat_yaml",
+        "//3rdparty/jvm/com/fasterxml/jackson/module:jackson_module_parameter_names",
+        "//3rdparty/jvm/io/prometheus:simpleclient",
+        "//3rdparty/jvm/io/prometheus:simpleclient_httpserver",
+        "//3rdparty/jvm/org/apache/kafka:kafka_clients",
+        "//3rdparty/jvm/org/slf4j:slf4j_api",
+        "//3rdparty/jvm_shaded/com/google/guava_shaded",
+    ],
+)

--- a/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/Enforcer.java
+++ b/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/Enforcer.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import static tesla.shade.com.google.common.base.Preconditions.checkArgument;
+import static tesla.shade.com.google.common.base.Preconditions.checkState;
+
+import io.prometheus.client.Gauge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Enforcer detects a drift between expected & actual cluster state, if drift is found it enforces the desired state.
+ *
+ * @param <T> type of the enforceable entity.
+ */
+public abstract class Enforcer<T> {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(Enforcer.class);
+  // we do not allow more than this % of entities to be deleted in a single run
+  protected static final float PERMISSIBLE_DELETION_THRESHOLD = 0.50f;
+  protected static final Gauge absentEntities = Gauge.build()
+      .name("kafka_enforcer_absent")
+      .help("Count of entities that are absent from the cluster.")
+      .register();
+  protected static final Gauge unexpectedEntities = Gauge.build()
+      .name("kafka_enforcer_unexpected")
+      .help("Count of entities that are unexpectedly present in the cluster.")
+      .register();
+  protected static final Gauge configuredEntities = Gauge.build()
+      .name("kafka_enforcer_configured")
+      .help("Count of configured entities.")
+      .register();
+
+  protected final Collection<T> configured;
+  protected final Supplier<Collection<T>> existing;
+  protected final BiPredicate<T, T> isEqual;
+  protected final boolean safemode;
+
+  /**
+   * The constructor.
+   *
+   * @param configured list of configured entities, ex: topics, acls, etc., this list defines the desired state
+   * @param existing   a supplier to fetch the actual state
+   * @param isEqual    a predicate to check if two entities are same
+   * @param safemode   if true, certain risky operations (ex: deletion) are skipped
+   */
+  protected Enforcer(Collection<T> configured, Supplier<Collection<T>> existing, BiPredicate<T, T> isEqual, boolean safemode) {
+    long distinct = configured.stream().distinct().count();
+    checkArgument(configured.size() == distinct, "Found duplicate entities in config");
+    checkArgument(safemode || configured.size() != 0, "Configured entities should not be empty if safemode is off");
+    this.isEqual = isEqual;
+    this.configured = configured;
+    this.existing = existing;
+    this.safemode = safemode;
+  }
+
+  /**
+   * Alter entities whose configuration as drifted. Default behavior is a no-op.
+   */
+  protected void alterDrifted() {
+    // no-op
+  }
+
+  /**
+   * Create new entities.
+   *
+   * @param toCreate a list of entities that need to be created
+   */
+  protected abstract void create(List<T> toCreate);
+
+  /**
+   * Delete existing entities.
+   *
+   * @param toDelete a list of entities that need to be deleted
+   */
+  protected abstract void delete(List<T> toDelete);
+
+  /**
+   * Get a list of entities that are expected to be present, but they are not.
+   *
+   * @return a list of entities
+   */
+  public List<T> absent() {
+    if (this.configured.isEmpty()) {
+      return Collections.emptyList();
+    }
+    Collection<T> existing = this.existing.get();
+    return Collections.unmodifiableList(
+        this.configured
+            .stream()
+            .filter(c -> existing.stream().noneMatch(e -> isEqual.test(c, e)))
+            .collect(Collectors.toList())
+    );
+  }
+
+  /**
+   * Get a list of entities that are not expected to be present, but they are.
+   *
+   * @return a list of entities
+   */
+  public List<T> unexpected() {
+    return Collections.unmodifiableList(
+        existing.get()
+            .stream()
+            .filter(e -> this.configured.stream().noneMatch(c -> isEqual.test(c, e)))
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * Create missing entities.
+   */
+  public void createAbsent() {
+    List<T> toCreate = absent();
+    if (!toCreate.isEmpty()) {
+      LOG.info("Creating {} new entities: {}", toCreate.size(), toCreate);
+      create(toCreate);
+    } else {
+      LOG.info("No new entity was discovered.");
+    }
+  }
+
+  /**
+   * Delete un-expected entities.
+   */
+  public void deleteUnexpected() {
+    checkState(!safemode, "Deletion is not allowed in safe mode");
+    checkState(configured.size() > 0, "Configured entities can not be empty");
+    List<T> toDelete = unexpected();
+    float destruction = toDelete.size() * 1.0f / configured.size();
+    checkState(destruction <= PERMISSIBLE_DELETION_THRESHOLD,
+        "Too many [%s%] entities being deleted in one run", destruction * 100);
+    if (!toDelete.isEmpty()) {
+      LOG.info("Deleting {} redundant entities: {}", toDelete.size(), toDelete);
+      delete(toDelete);
+    } else {
+      LOG.info("No un-expected entity was found.");
+    }
+  }
+
+  /**
+   * Run enforcement.
+   */
+  public void enforceAll() {
+    LOG.info("\n--Enforcement run started--");
+    createAbsent();
+    alterDrifted();
+    if (!safemode) {
+      deleteUnexpected();
+    }
+    LOG.info("\n--Enforcement run ended--");
+  }
+
+  /**
+   * Record stats.
+   */
+  public void stats() {
+    absentEntities.set(absent().size());
+    unexpectedEntities.set(unexpected().size());
+    configuredEntities.set(configured.size());
+  }
+
+}

--- a/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/BUILD
+++ b/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/BUILD
@@ -1,0 +1,22 @@
+java_library(
+    name = "dummy",
+    srcs = [
+        "Dummy.java",
+        "DummyEnforcer.java",
+    ],
+    deps = [
+        "//kafka_enforcer_common/src/main/java/com/tesla/data/enforcer",
+    ],
+)
+
+java_test(
+    name = "EnforcerTest",
+    srcs = [
+        "EnforcerTest.java",
+    ],
+    deps = [
+        ":dummy",
+        "//3rdparty/jvm/org/mockito:mockito_core",
+        "//kafka_enforcer_common/src/main/java/com/tesla/data/enforcer",
+    ],
+)

--- a/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/Dummy.java
+++ b/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/Dummy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A dummy enforceable entity.
+ */
+public class Dummy {
+  final String name;
+  final Map<String, String> config;
+
+  public Dummy(String name, Map<String, String> config) {
+    if (name == null || config == null) {
+      throw new IllegalArgumentException(
+          String.format("Invalid args, name=%s, config=%s", name, config));
+    }
+    this.name = name;
+    this.config = config;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Dummy dummy = (Dummy) o;
+    return name.equals(dummy.name) &&
+        config.equals(dummy.config);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, config);
+  }
+}

--- a/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/DummyEnforcer.java
+++ b/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/DummyEnforcer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * A dummy implementation of enforcer meant for testing.
+ */
+public class DummyEnforcer extends Enforcer<Dummy> {
+
+  DummyEnforcer(
+      Collection<Dummy> configured, Supplier<Collection<Dummy>> existing, boolean safemode) {
+    super(configured, existing, Dummy::equals, safemode);
+  }
+
+  DummyEnforcer(Collection<Dummy> configured, Supplier<Collection<Dummy>> existing) {
+    this(configured, existing, true);
+  }
+
+  @Override
+  protected void create(List<Dummy> toCreate) {
+    // no-op
+  }
+
+  @Override
+  protected void delete(List<Dummy> toDelete) {
+    // no-op
+  }
+}

--- a/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/EnforcerTest.java
+++ b/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/EnforcerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class EnforcerTest {
+
+  private static final List<Dummy> dummies =
+      Arrays.asList(new Dummy("a", emptyMap()), new Dummy("b", emptyMap()));
+  private DummyEnforcer enforcer;
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDuplicateConfigured() {
+    new DummyEnforcer(Collections.nCopies(2, dummies.get(0)), Collections::emptyList);
+  }
+
+  @Test
+  public void testAbsent() {
+    enforcer = new DummyEnforcer(dummies, () -> singletonList(dummies.get(0)));
+    Assert.assertEquals(singletonList(dummies.get(1)), enforcer.absent());
+  }
+
+  @Test
+  public void testAbsentNoneExisting() {
+    enforcer = new DummyEnforcer(dummies, Collections::emptyList);
+    Assert.assertEquals(dummies, enforcer.absent());
+  }
+
+  @Test
+  public void testAbsentNoneConfigured() {
+    enforcer = new DummyEnforcer(emptyList(), () -> dummies);
+    Assert.assertTrue(enforcer.absent().isEmpty());
+  }
+
+  @Test
+  public void testNoUnexpected() {
+    enforcer = new DummyEnforcer(dummies, () -> dummies);
+    Assert.assertTrue(enforcer.unexpected().isEmpty());
+  }
+
+  @Test
+  public void testUnexpected() {
+    Dummy unexpected = new Dummy("x", emptyMap());
+    enforcer = new DummyEnforcer(dummies, () -> singletonList(unexpected));
+    Assert.assertEquals(1, enforcer.unexpected().size());
+    Assert.assertEquals(unexpected, enforcer.unexpected().get(0));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testSafeMode() {
+    enforcer = new DummyEnforcer(dummies, Collections::emptyList);
+    enforcer.deleteUnexpected();
+  }
+
+  @Test
+  public void testSafeModeEnforceAll() {
+    Dummy unexpected = new Dummy("x", emptyMap());
+
+    // safemode on
+    enforcer = spy(new DummyEnforcer(dummies, () -> singletonList(unexpected), true));
+    enforcer.enforceAll();
+    verify(enforcer, times(0)).delete(anyListOf(Dummy.class));
+
+    // safemode off
+    enforcer = spy(new DummyEnforcer(dummies, () -> singletonList(unexpected), false));
+    enforcer.enforceAll();
+    verify(enforcer, times(1)).delete(singletonList(unexpected));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptyConfigSafeModeOff() {
+    enforcer = new DummyEnforcer(emptyList(), Collections::emptyList, false);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testTooManyBeingDeleted() {
+    enforcer =
+        new DummyEnforcer(
+            dummies,
+            () -> Arrays.asList(new Dummy("x", emptyMap()), new Dummy("y", emptyMap())),
+            false);
+    // should not be allowed as we are deleting lot of dummies!
+    enforcer.deleteUnexpected();
+  }
+}


### PR DESCRIPTION
This change extracts enforcement loop into a common lib & makes
it entity agnostic. This is prep work for acl enforcer, goal is
to re-use core pieces present in topic enforcer.