### PR TITLE
Pull BaseCommand, EnforceCommand & ClusterEntities into common

### DIFF
--- a/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/BaseCommand.java
+++ b/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/BaseCommand.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tesla.shade.com.google.common.io.Resources;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * All enforcement related CLI tools are an extension of {@link BaseCommand}.
+ */
+@Parameters(commandDescription = "Validate config")
+public class BaseCommand<T> {
+
+  protected static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {
+  };
+  protected static int SUCCESS = 0;
+  protected static int FAILURE = 1;
+
+  static {
+    MAPPER.registerModule(new ParameterNamesModule());
+  }
+
+  protected final Logger LOG = LoggerFactory.getLogger(getClass());
+  @Parameter(
+      description = "/path/to/a/configuration/file",
+      required = true,
+      converter = CommandConfigConverter.class)
+  private Map<String, Object> cmdConfig = null;
+
+  @Parameter(
+      names = {"--cluster"},
+      description = "a cluster name, if specified, " +
+          "consolidated (multi-cluster) configuration file is expected")
+  private String cluster = null;
+
+  public BaseCommand() {
+    // DO NOT REMOVE, this is needed by jcommander
+  }
+
+  public BaseCommand(Map<String, Object> cmdConfig) {
+    this(cmdConfig, null);
+  }
+
+  public BaseCommand(Map<String, Object> cmdConfig, String cluster) {
+    this.cmdConfig = cmdConfig;
+    this.cluster = cluster;
+  }
+
+  Map<String, Object> cmdConfig() {
+    Objects.requireNonNull(cmdConfig, "command has not been initialized with config");
+    return cmdConfig;
+  }
+
+  public Map<String, Object> kafkaConfig() {
+    return MAPPER.convertValue(cmdConfig().get("kafka"), MAP_TYPE);
+  }
+
+  public List<T> configuredEntities(Class<T> toValueType, String entitiesKey, String entitiesFileKey) {
+    Object entities = cmdConfig.containsKey(entitiesKey) ? cmdConfig.get(entitiesKey) : cmdConfig.get(entitiesFileKey);
+    Objects.requireNonNull(entities, "Missing entities in config");
+    List<Map<String, Object>> unParsed = configuredEntities(cmdConfig, entitiesKey, entitiesFileKey);
+    List<Map<String, Object>> forCluster =
+        cluster == null ? unParsed : ClusterEntities.forCluster(unParsed, cluster);
+    return forCluster.stream()
+        .map(t -> MAPPER.convertValue(t, toValueType))
+        .collect(Collectors.toList());
+  }
+
+  // un-parsed list of configured entities
+  private List<Map<String, Object>> configuredEntities(Map<String, Object> cmdConfig, String entitiesKey, String entitiesFileKey) {
+    TypeReference<List<Map<String, Object>>> listOfMaps =
+        new TypeReference<List<Map<String, Object>>>() {
+        };
+    if (cmdConfig.containsKey(entitiesKey)) {
+      return MAPPER.convertValue(cmdConfig.get(entitiesKey), listOfMaps);
+    } else {
+      try {
+        String entitiesFile = (String) cmdConfig.get(entitiesFileKey);
+        final InputStream is;
+        if (Files.exists(Paths.get(entitiesFile))) {
+          is = new FileInputStream(entitiesFile);
+        } else {
+          is = Resources.getResource(entitiesFile).openStream();
+        }
+        return MAPPER.readValue(is, listOfMaps);
+      } catch (IOException e) {
+        throw new ParameterException(
+            "Could not load entities from file " + cmdConfig.get(entitiesFileKey), e);
+      }
+    }
+  }
+
+  public int run() {
+    System.out.println("Kafka connection: " + kafkaConfig().get("bootstrap.servers"));
+    System.out.println("Config looks good!");
+    return SUCCESS;
+  }
+
+  /**
+   * An converter that converts yaml config file to a config stored in a java map.
+   */
+  public static class CommandConfigConverter implements IStringConverter<Map<String, Object>> {
+    @Override
+    public Map<String, Object> convert(String file) {
+      try {
+        return convert(new FileInputStream(file));
+      } catch (IOException e) {
+        throw new ParameterException("Could not load config from file " + file, e);
+      }
+    }
+
+    public Map<String, Object> convert(InputStream is) throws IOException {
+      Map<String, Object> cmdConfig = MAPPER.readValue(is, MAP_TYPE);
+      Objects.requireNonNull(cmdConfig.get("kafka"), "Missing kafka connection settings from config");
+      return cmdConfig;
+    }
+  }
+
+}

--- a/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/ClusterEntities.java
+++ b/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/ClusterEntities.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import static tesla.shade.com.google.common.base.Preconditions.checkArgument;
+
+import tesla.shade.com.google.common.collect.Sets;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A utility class to parse consolidated (multi-cluster) configurations. The structure of a consolidated config is,
+ *
+ * <pre>{@code
+ * ---
+ * clusters:
+ *   foo:
+ *       bootstrap.servers: 'foo_1:9092,foo_2:9092,foo_3:9092'
+ *   bar:
+ *       bootstrap.servers: 'bar_1:9092,bar_2:9092,bar_3:9092'
+ * topics:
+ *   - name: topic_A
+ *     partitions: 30
+ *     replicationFactor: 3
+ *     clusters:
+ *       foo: {}
+ *       bar:
+ *         replicationFactor: 2
+ *   - name: topic_B
+ *     partitions: 10
+ *     replicationFactor: 3
+ *     clusters:
+ *       foo: {}
+ *
+ * ---
+ *
+ * }</pre>
+ *
+ * Rules for filtering Entities & applying cluster overrides to the base config are,
+ *
+ * <ul>
+ * <li>An entry is applicable to a cluster if that cluster is present under entry's 'clusters'
+ * attribute. If no changes to base config are desired, specify empty dict '{}'
+ * <li>All properties can be overridden, except name
+ * <li>Map (dictionary) properties are merged in way that preserves base settings
+ * </ul>
+ */
+public class ClusterEntities {
+
+  public static final String CLUSTERS = "clusters";
+
+  /**
+   * Get Entities configurations for a given cluster.
+   *
+   * @param allEntities a list containing all consolidated (all clusters) configurations
+   * @param cluster     the name of the cluster to filter Entities on
+   * @return a list of entity configurations for the given cluster
+   * @throws IllegalArgumentException if invalid config structure is passed
+   */
+  public static List<Map<String, Object>> forCluster(
+      List<Map<String, Object>> allEntities, String cluster) {
+    Map<String, List<Map<String, Object>>> map = new HashMap<>();
+    allEntities.forEach(
+        tc -> {
+          /*
+          expected structure for an entry 'tc' is:
+          {
+            name: some_topic
+            partitions: 10
+            replicationFactor: 3
+            clusters:
+              foo: {}
+              bar:
+                replicationFactor: 2
+          }
+          */
+          checkArgument(tc.containsKey(CLUSTERS), "%s does not contain cluster overrides", tc);
+          Map<String, Map<String, Object>> clusters =
+              (Map<String, Map<String, Object>>) tc.get(CLUSTERS);
+
+          // base configuration is everything except the overrides under 'clusters' key
+          Map<String, Object> baseConfig = new HashMap<>(tc);
+          baseConfig.remove(CLUSTERS);
+
+          clusters.forEach(
+              (c, o) ->
+                  map.computeIfAbsent(c, k -> new LinkedList<>())
+                      .add(applyOverrides(baseConfig, o)));
+        });
+
+    return map.getOrDefault(cluster, Collections.emptyList());
+  }
+
+  // override all properties
+  private static Map<String, Object> applyOverrides(
+      Map<String, Object> base, Map<String, Object> overrides) {
+    Map<String, Object> result = new HashMap<>(base);
+    Set<String> properties = Sets.union(base.keySet(), overrides.keySet());
+    properties.forEach(
+        p -> {
+          Object newValue = overrides.containsKey(p) ? overrides.get(p) : base.get(p);
+          result.merge(p, newValue, ClusterEntities::remap);
+        });
+    return result;
+  }
+
+  // override a single property
+  private static Object remap(Object originalValue, Object overrideValue) {
+    if (originalValue instanceof Map) {
+      checkArgument(overrideValue instanceof Map);
+      ((Map) originalValue).putAll((Map) overrideValue);
+      return originalValue;
+    }
+    return overrideValue;
+  }
+}

--- a/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/EnforceCommand.java
+++ b/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/EnforceCommand.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import static tesla.shade.com.google.common.base.Preconditions.checkNotNull;
+import static tesla.shade.com.google.common.base.Preconditions.checkState;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.exporter.HTTPServer;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Supplier;
+
+@Parameters(commandDescription = "Enforce given configuration")
+public class EnforceCommand<T> extends BaseCommand<T> {
+
+  private static final Gauge lastSuccess = Gauge.build()
+      .name("kafka_enforcer_run_last_success_timestamp")
+      .help("Timestamp of last successful run as epoch seconds.")
+      .register();
+  private static final Counter failures = Counter.build()
+      .name("kafka_enforce_run_failures_total")
+      .help("Total failures so far.")
+      .register();
+  private static final Counter runs = Counter.build()
+      .name("kafka_enforcer_run_total")
+      .help("Total runs so far.")
+      .register();
+
+  @Parameter(
+      names = {"--dryrun", "-d"},
+      description = "do a dry run")
+  protected boolean dryrun = false;
+  @Parameter(
+      names = {"--unsafemode"},
+      description = "run in unsafe mode, deletion is _only_ allowed in this mode")
+  protected boolean unsafemode = false;
+  @Parameter(
+      names = {"--continuous", "-c"},
+      description = "run enforcement continuously")
+  protected boolean continuous = false;
+  @Parameter(
+      names = {"--interval", "-i"},
+      description = "run interval for continuous mode in seconds",
+      arity = 1)
+  protected int interval = 600;
+
+  private Enforcer<T> enforcer;
+
+  EnforceCommand() {
+    // DO NOT REMOVE, this is needed by jcommander
+  }
+
+  // This constructor is only meant for testing. In a non-testing/real scenario, the subclass must override
+  // initEnforcer and initialize the enforcer.
+  EnforceCommand(Enforcer<T> enforcer, Map<String, Object> cmdConfig, boolean continuous, int interval) {
+    super(cmdConfig);
+    this.enforcer = enforcer;
+    this.continuous = continuous;
+    this.interval = interval;
+  }
+
+  /**
+   * Initialize the enforcer. Base classes must override this method.
+   *
+   * @param adminClient a kafka admin client
+   * @return an enforcer instance
+   */
+  protected Enforcer<T> initEnforcer(AdminClient adminClient) {
+    return checkNotNull(enforcer, "Enforcer is expected to be initialized when command instance is created " +
+        "for a test.");
+  }
+
+  @Override
+  public int run() {
+    try (AdminClient kafka = KafkaAdminClient.create(kafkaConfig())) {
+      checkState(enforcer == null, "Enforcer is expected to be un-initialized when command " +
+          "instance is created by CLI");
+      this.enforcer = initEnforcer(kafka);
+      return doRun(() -> false);
+    }
+  }
+
+  // for testing
+  int doRun(final Supplier<Boolean> stopCondition) {
+    LOG.info("Dry run is {}, safe mode is {}", dryrun ? "ON" : "OFF", unsafemode ? "OFF" : "ON");
+    if (!continuous) {
+      return runOnceIgnoreError();
+    }
+
+    // continuous mode
+    HTTPServer server = null;
+    final int port = (int) cmdConfig().getOrDefault("metricsPort", 8081);
+    try {
+      server = metricServer(port);
+      LOG.info("Started metrics server at port {}", port);
+      while (!stopCondition.get()) {
+        runOnceIgnoreError();
+        Thread.sleep(interval * 1000);
+      }
+    } catch (Exception e) {
+      // exception caught here must have come prometheus server or thread interrupt
+      // all other exceptions are swallowed by runOnceIgnoreError routine
+      LOG.error("Unexpected error", e);
+      return FAILURE;
+    } finally {
+      if (server != null) {
+        server.stop();
+      }
+    }
+    return SUCCESS;
+  }
+
+  // for testing
+  HTTPServer metricServer(int port) throws IOException {
+    return new HTTPServer(port, true);
+  }
+
+  private int runOnceIgnoreError() {
+    try {
+      runs.inc();
+      // Stats should be recorded before enforcement or else we will miss all anomalies
+      this.enforcer.stats();
+      this.enforcer.enforceAll();
+      lastSuccess.setToCurrentTime();
+      return SUCCESS;
+    } catch (Exception e) {
+      LOG.error("Enforcer run failed!", e);
+      failures.inc();
+      return FAILURE;
+    }
+  }
+
+}

--- a/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/BUILD
+++ b/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/BUILD
@@ -10,6 +10,45 @@ java_library(
 )
 
 java_test(
+    name = "ClusterEntitiesTest",
+    srcs = [
+        "ClusterEntitiesTest.java",
+    ],
+    deps = [
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_databind",
+        "//3rdparty/jvm/com/fasterxml/jackson/dataformat:jackson_dataformat_yaml",
+        "//kafka_enforcer_common/src/main/java/com/tesla/data/enforcer",
+    ],
+)
+
+java_test(
+    name = "BaseCommandTest",
+    srcs = [
+        "BaseCommandTest.java",
+    ],
+    deps = [
+        ":dummy",
+        "//3rdparty/jvm/org/mockito:mockito_core",
+        "//kafka_enforcer_common/src/main/java/com/tesla/data/enforcer",
+    ],
+)
+
+java_test(
+    name = "EnforceCommandTest",
+    srcs = [
+        "EnforceCommandTest.java",
+    ],
+    deps = [
+        ":dummy",
+        "//3rdparty/jvm/ch/qos/logback:logback_classic",
+        "//3rdparty/jvm/io/prometheus:simpleclient_httpserver",
+        "//3rdparty/jvm/org/mockito:mockito_core",
+        "//kafka_enforcer_common/src/main/java/com/tesla/data/enforcer",
+    ],
+)
+
+java_test(
     name = "EnforcerTest",
     srcs = [
         "EnforcerTest.java",

--- a/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/BaseCommandTest.java
+++ b/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/BaseCommandTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import com.tesla.data.enforcer.BaseCommand.CommandConfigConverter;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+public class BaseCommandTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  private static final String testConf =
+      "---\n"
+          + "kafka:\n"
+          + "    bootstrap.servers: localhost:9092\n"
+          + "\n"
+          + "dummies:\n"
+          + "    - name: dummy_a\n"
+          + "      config:\n"
+          + "          k1: v1\n"
+          + "          k2: v2\n"
+          + "    - name: dummy_b\n"
+          + "      config: {}";
+  private final CommandConfigConverter converter = new CommandConfigConverter();
+
+  private static InputStream confStream(String confStr) {
+    return new ByteArrayInputStream(confStr.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void tesConverter() throws IOException {
+    Map<String, Object> config = converter.convert(confStream(testConf));
+    Assert.assertTrue(config.containsKey("kafka"));
+    Assert.assertTrue(config.containsKey("dummies"));
+  }
+
+  @Test
+  public void testConfiguredT() throws IOException {
+    Map<String, Object> config = converter.convert(confStream(testConf));
+    List<Dummy> configured =
+        new BaseCommand<Dummy>(config).configuredEntities(Dummy.class, "dummies", "dummiesFile");
+    Assert.assertEquals(2, configured.size());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfiguredBad() throws IOException {
+    String badConf =
+        "---\n"
+            + "kafka:\n"
+            + "  bootstrap.servers: localhost:9092\n"
+            + "dummies:\n"
+            + "  - name: dummy_a\n";
+    Map<String, Object> config = converter.convert(confStream(badConf));
+    new BaseCommand<Dummy>(config).configuredEntities(Dummy.class, "dummies", "dummiesFile");
+  }
+
+  private Map<String, Object> configWithEntitiesFile(String data) throws IOException {
+    File tempFile = TEMP_FOLDER.newFile();
+    Files.write(Paths.get(tempFile.getPath()), data.getBytes());
+
+    String testConf =
+        String.join(
+            "\n",
+            new String[]{
+                "---",
+                "kafka:",
+                "  bootstrap.servers: localhost:9092",
+                "dummiesFile: " + tempFile.getPath()
+            });
+
+    return converter.convert(confStream(testConf));
+  }
+
+  @Test
+  public void testFromFile() throws IOException {
+    String dummies =
+        String.join(
+            "\n",
+            new String[]{
+                "---",
+                "- name: dummy_a",
+                "  config: {}"
+            });
+    Assert.assertEquals(
+        1,
+        new BaseCommand<Dummy>(configWithEntitiesFile(dummies))
+            .configuredEntities(Dummy.class, "dummies", "dummiesFile")
+            .size());
+  }
+
+  @Test
+  public void testClusterEntitiesFromFile() throws IOException {
+    String dummies =
+        String.join(
+            "\n",
+            new String[]{
+                "---",
+                "- name: dummy_a",
+                "  config: {}",
+                "  clusters:",
+                "    cluster_a: {}",
+            });
+    Assert.assertEquals(
+        1,
+        new BaseCommand<Dummy>(configWithEntitiesFile(dummies), "cluster_a")
+            .configuredEntities(Dummy.class, "dummies", "dummiesFile")
+            .size());
+    Assert.assertEquals(
+        0,
+        new BaseCommand<Dummy>(configWithEntitiesFile(dummies), "cluster_b")
+            .configuredEntities(Dummy.class, "dummies", "dummiesFile")
+            .size());
+  }
+
+}

--- a/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/ClusterEntitiesTest.java
+++ b/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/ClusterEntitiesTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ClusterEntitiesTest {
+
+  private static ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+  private static TypeReference<List<Map<String, Object>>> type =
+      new TypeReference<List<Map<String, Object>>>() {
+      };
+
+  private String conf =
+      String.join(
+          "\n",
+          new String[]{
+              "---",
+              "- name: topic_a",
+              "  partitions: 1",
+              "  replicationFactor: 1",
+              "  clusters:",
+              "      cluster_one: {}",
+              "      cluster_two: ",
+              "        replicationFactor: 2",
+              "- name: topic_b",
+              "  partitions: 1",
+              "  replicationFactor: 1",
+              "  clusters:",
+              "      cluster_three: ",
+              "        config: ",
+              "          k1: v1",
+              "      cluster_two: {}",
+          });
+
+  private String clusterOneFinal =
+      String.join(
+          "\n",
+          new String[]{
+              "---",
+              "- name: topic_a",
+              "  partitions: 1",
+              "  replicationFactor: 1"
+          });
+
+  private String clusterTwoFinal =
+      String.join(
+          "\n",
+          new String[]{
+              "---",
+              "- name: topic_a",
+              "  partitions: 1",
+              "  replicationFactor: 2",
+              "- name: topic_b",
+              "  partitions: 1",
+              "  replicationFactor: 1",
+          });
+
+  private String clusterThreeFinal =
+      String.join(
+          "\n",
+          new String[]{
+              "---",
+              "- name: topic_b",
+              "  partitions: 1",
+              "  replicationFactor: 1",
+              "  config: ",
+              "    k1: v1"
+          });
+
+  static List<Map<String, Object>> topics(String conf, String cluster) throws IOException {
+    return ClusterEntities.forCluster(mapper.readValue(conf, type), cluster);
+  }
+
+  @Test
+  public void testTopicsForCluster() throws IOException {
+    Assert.assertEquals(mapper.readValue(clusterOneFinal, type), topics(conf, "cluster_one"));
+    Assert.assertEquals(Collections.emptyList(), topics(conf, "cluster_four"));
+    Assert.assertEquals(1, topics(conf, "cluster_three").size());
+    Assert.assertEquals(2, topics(conf, "cluster_two").size());
+  }
+
+  @Test
+  public void testNonMapPropertiesAreOverridden() throws IOException {
+    Assert.assertEquals(mapper.readValue(clusterTwoFinal, type), topics(conf, "cluster_two"));
+  }
+
+  @Test
+  public void testExclusiveOverridesArePreserved() throws IOException {
+    Assert.assertEquals(mapper.readValue(clusterThreeFinal, type), topics(conf, "cluster_three"));
+  }
+
+  @Test
+  public void testMapPropertiesAreOverridden() throws IOException {
+    String conf = String.join(
+        "\n",
+        new String[]{
+            "---",
+            "- name: topic_a",
+            "  partitions: 1",
+            "  replicationFactor: 1",
+            "  config: ",
+            "    k1: v1",
+            "    k2: v2",
+            "  clusters:",
+            "    cluster: ",
+            "      config: ",
+            "        k2: v2.1",
+        });
+    String clusterFinal = String.join(
+        "\n",
+        new String[]{
+            "---",
+            "- name: topic_a",
+            "  partitions: 1",
+            "  replicationFactor: 1",
+            "  config: ",
+            "    k1: v1",
+            "    k2: v2.1"
+        });
+    Assert.assertEquals(mapper.readValue(clusterFinal, type), topics(conf, "cluster"));
+  }
+
+}

--- a/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/EnforceCommandTest.java
+++ b/kafka_enforcer_common/src/test/java/com/tesla/data/enforcer/EnforceCommandTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2020. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.enforcer;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.tesla.data.enforcer.BaseCommand.CommandConfigConverter;
+
+import io.prometheus.client.exporter.HTTPServer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class EnforceCommandTest {
+
+  private static final String testConf = "---\n" +
+      "kafka:\n" +
+      "    bootstrap.servers: localhost:9092\n" +
+      "\n" +
+      "dummies:\n" +
+      "    - name: a\n" +
+      "      config: {}\n";
+  private final CommandConfigConverter converter = new CommandConfigConverter();
+
+  @Mock
+  private Enforcer<Dummy> enforcer;
+  private HTTPServer metricServer;
+
+  private Map<String, Object> config;
+
+  private static int findFreePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      socket.setReuseAddress(true);
+      return socket.getLocalPort();
+    }
+  }
+
+  @Before
+  public void setup() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    config = converter.convert(
+        new ByteArrayInputStream(testConf.getBytes(StandardCharsets.UTF_8)));
+    config.put("metricsPort", findFreePort());
+    metricServer = mock(HTTPServer.class);
+  }
+
+  private void check(final EnforceCommand<Dummy> command, final int count) {
+    Supplier<Boolean> stop = new Supplier<Boolean>() {
+      private int runs = 0;
+
+      @Override
+      public Boolean get() {
+        return ++runs > count;
+      }
+    };
+    command.doRun(stop);
+    verify(enforcer, times(count)).stats();
+    verify(enforcer, times(count)).enforceAll();
+    verifyNoMoreInteractions(enforcer);
+  }
+
+  @Test
+  public void testNotContinuousMode() {
+    EnforceCommand<Dummy> command = new EnforceCommand<>(enforcer, config, false, 0);
+    check(command, 1);
+  }
+
+  @Test
+  public void testContinuousModeHappy() {
+    EnforceCommand<Dummy> command = new EnforceCommand<>(enforcer, config, true, 0);
+    check(command, 2);
+  }
+
+  @Test
+  public void testContinuousModeFailure() {
+    // first run fails
+    doThrow(new RuntimeException("failed")).doNothing().when(enforcer).enforceAll();
+    EnforceCommand<Dummy> command = new EnforceCommand<>(enforcer, config, true, 0);
+    check(command, 2);
+  }
+
+  @Test
+  public void testMetricServer() throws IOException {
+    EnforceCommand<Dummy> command = spy(new EnforceCommand<>(enforcer, config, true, 0));
+    doReturn(metricServer).when(command).metricServer(anyInt());
+    check(command, 1);
+    verify(metricServer).stop();
+    verifyNoMoreInteractions(metricServer);
+  }
+
+  @Test
+  public void testNoMetricServer() throws IOException {
+    EnforceCommand<Dummy> command = spy(new EnforceCommand<>(enforcer, config, false, 0));
+    verify(command, never()).metricServer(anyInt());
+  }
+
+  @Test
+  public void testAbortIfMetricServerFails() throws IOException {
+    EnforceCommand<Dummy> command = spy(new EnforceCommand<>(enforcer, config, true, 0));
+    doThrow(new IOException("failed")).when(command).metricServer(anyInt());
+    check(command, 0);
+    verify(command).metricServer(anyInt());
+  }
+
+}


### PR DESCRIPTION
This change extracts few more abstractions into a common lib
& makes it entity agnostic. This is prep work for acl enforcer,
goal is to re-use core pieces present in topic enforcer.