### PR TITLE
Make BaseCommand public again

### DIFF
--- a/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/BUILD
+++ b/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/BUILD
@@ -1,8 +1,7 @@
-package(default_visibility = ["//:__subpackages__"])
-
 java_library(
     name = "enforcer",
     srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
     deps = [
         "//3rdparty/jvm/com/beust:jcommander",
         "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_annotations",


### PR DESCRIPTION
In a recent refactoring exercise the visibility was downgraded