### PR TITLE
Do a basic health check on burrow during app initialization

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -121,7 +121,6 @@ public class ConsumerFreshness {
         }).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
 
     this.executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(workerThreadCount));
-    this.metrics.register();
   }
 
   private KafkaConsumer createConsumer(Map<String, Object> conf) {
@@ -155,6 +154,7 @@ public class ConsumerFreshness {
       try {
         clusters = burrow.getClusters();
       } catch (IOException e) {
+        LOG.error("Failed to read from burrow", e);
         this.metrics.burrowClustersReadFailed.inc();
         return null;
       }

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
@@ -4,64 +4,67 @@
 
 package com.tesla.data.consumer.freshness;
 
-import static tesla.shade.com.google.common.collect.Lists.newArrayList;
-
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
-import io.prometheus.client.SimpleCollector;
 import io.prometheus.client.Summary;
 
 public class FreshnessMetrics {
+
+  public FreshnessMetrics() {
+    /*
+    The ideal way to register a metric is to define a static class variable, but
+    that approach does not allow us to unit-test the instrumentation code path, since
+    within tests, we have to 'reset' metric values. Prometheus registries themselves are
+    static and  do not allow re-registration of a metric. Finally, we want 'in-line'
+    registration of metrics as opposed to explicit registration. Given these constraints,  we
+    clear the default prometheus registry which removes all previous registrations.
+     */
+    CollectorRegistry.defaultRegistry.clear();
+  }
+
   Summary elapsed = new Summary.Builder()
       .name("kafka_consumer_freshness_runtime_sec")
       .help("Elapsed runtime (sec) of a single freshness tracker run")
-      .create();
+      .register();
   Counter missing = new Counter.Builder()
       .name("kafka_consumer_freshness_runtime_missing")
       .help("Number of partitions where there is a consumer, but no offset stored in Burrow")
-      .create();
+      .register();
   Counter kafkaRead = new Counter.Builder()
       .name("kafka_consumer_freshness_runtime_total_kafka_read")
       .help("Number of offsets loaded from Kafka")
       .labelNames("cluster", "consumer")
-      .create();
+      .register();
   Counter failed = new Counter.Builder()
       .name("kafka_consumer_freshness_runtime_failed_kafka_read")
       .help("Number of offsets that failed to be loaded from Kafka (consumers too old?)")
       .labelNames("cluster", "consumer")
-      .create();
+      .register();
   Counter invalid = new Counter.Builder()
       .name("kafka_consumer_freshness_runtime_invalid_kafka_read")
       .help("Number of offsets that loaded from Kafka but were found to be invalid (producer sent invalid timestamp?)")
       .labelNames("cluster", "consumer")
-      .create();
+      .register();
   Counter error = new Counter.Builder()
       .name("kafka_consumer_freshness_runtime_query_exception")
       .help("Number of Kafka queries that threw an exception")
       .labelNames("cluster", "consumer")
-      .create();
+      .register();
   Counter burrowClustersReadFailed = new Counter.Builder()
       .name("kafka_consumer_freshness_runtime_failed_burrow_clusters_read")
       .help("Number of times we failed to lookup the clusters from burrow")
-      .create();
+      .register();
   Gauge freshness = new Gauge.Builder()
       .name("kafka_consumer_freshness_ms")
       .help("Difference between when the most recent committed offset entered a topic/partition and the timestamp " +
           "of the current Log-End-Offset")
       .labelNames("cluster", "consumer", "topic", "partition")
-      .create();
+      .register();
   Histogram kafkaQueryLatency = new Histogram.Builder()
       .name("kafka_consumer_freshness_runtime_kafka_query_time")
       .help("Time spent making the actual queries for kafka time")
       .labelNames("type")
-      .create();
-
-
-  public void register() {
-    for (SimpleCollector collector :
-        newArrayList(elapsed, missing, kafkaRead, failed, invalid, error, freshness, kafkaQueryLatency)) {
-      collector.register();
-    }
-  }
+      .register();
 }


### PR DESCRIPTION
This change adds a sanity check during burrow client initialization.
App will abort if it fails to detect a healthy burrow.

Also, it was noticed that some metrics were not being registered.
As a fix, this change moves metric registration inline as opposed
to a whitelist.