### PR TITLE
Add a metric to track last successful run timestamp per cluster

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -186,6 +186,7 @@ public class ConsumerFreshness {
   private List<ListenableFuture> measureCluster(Burrow.ClusterClient client) {
     List<ListenableFuture> completed = new ArrayList<>();
     try {
+      metrics.lastClusterRunAttempt.labels(client.getCluster()).setToCurrentTime();
       ArrayBlockingQueue<KafkaConsumer> workers = this.availableWorkers.get(client.getCluster());
       List<String> consumerGroups = client.consumerGroups();
       Collections.sort(consumerGroups); // add some sanity to the logs
@@ -233,6 +234,7 @@ public class ConsumerFreshness {
           completed.add(result);
         }
       }
+      metrics.lastClusterRunSuccessfulAttempt.labels(client.getCluster()).setToCurrentTime();
     } catch (IOException | InterruptedException e) {
       LOG.error("Failed to handle cluster {}", client.getCluster(), e);
     }

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
@@ -67,4 +67,14 @@ public class FreshnessMetrics {
       .help("Time spent making the actual queries for kafka time")
       .labelNames("type")
       .register();
+  Gauge lastClusterRunAttempt = Gauge.build()
+      .name("kafka_consumer_freshness_last_run_timestamp")
+      .help("Timestamp of last run as epoch seconds.")
+      .labelNames("cluster")
+      .register();
+  Gauge lastClusterRunSuccessfulAttempt = Gauge.build()
+      .name("kafka_consumer_freshness_last_success_run_timestamp")
+      .help("Timestamp of last successful run as epoch seconds.")
+      .labelNames("cluster")
+      .register();
 }


### PR DESCRIPTION
This provides us with a direct indicator to alert on, ex: last run was N hours ago