### PR TITLE
Expose ACL enforcer command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup bin directory
         run: |
           mkdir -p $HOME/bin
-          echo "::add-path::$HOME/bin"
+          echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Setup build dependencies
         run: |

--- a/kafka_acl_enforcer/src/main/java/com/tesla/data/acl/AclEnforceCommand.java
+++ b/kafka_acl_enforcer/src/main/java/com/tesla/data/acl/AclEnforceCommand.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2020 Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.acl;
+
+import com.tesla.data.acl.mixin.Json;
+import com.tesla.data.enforcer.EnforceCommand;
+import com.tesla.data.enforcer.Enforcer;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.common.acl.AclBinding;
+
+import java.util.Map;
+
+public class AclEnforceCommand extends EnforceCommand<AclBinding> {
+  static {
+    Json.addMixIns(MAPPER);
+  }
+
+  public AclEnforceCommand() {
+    // DO NOT REMOVE, this is needed by jcommander
+  }
+
+  public AclEnforceCommand(Map<String, Object> cmdConfig) {
+    this(cmdConfig, null);
+  }
+
+  public AclEnforceCommand(Map<String, Object> cmdConfig, String cluster) {
+    this.cmdConfig = cmdConfig;
+    this.cluster = cluster;
+  }
+
+  @Override
+  protected Enforcer<AclBinding> initEnforcer(AdminClient client) {
+    return new AclEnforcer(configuredEntities(AclBinding.class, "acls", "aclsFile"),
+        new AclService(client), !unsafemode, dryrun);
+  }
+}
+

--- a/kafka_acl_enforcer/src/main/java/com/tesla/data/acl/BUILD
+++ b/kafka_acl_enforcer/src/main/java/com/tesla/data/acl/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "enforcer",
@@ -16,7 +16,6 @@ java_library(
 java_binary(
     name = "Main",
     main_class = "com.tesla.data.acl.Main",
-    visibility = ["//visibility:public"],
     runtime_deps = [
         ":enforcer",
         "//3rdparty/jvm/ch/qos/logback:logback_classic",

--- a/kafka_acl_enforcer/src/main/java/com/tesla/data/acl/Main.java
+++ b/kafka_acl_enforcer/src/main/java/com/tesla/data/acl/Main.java
@@ -4,29 +4,16 @@
 
 package com.tesla.data.acl;
 
-import com.tesla.data.acl.mixin.Json;
 import com.tesla.data.enforcer.BaseCommand;
-import com.tesla.data.enforcer.EnforceCommand;
-import com.tesla.data.enforcer.Enforcer;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.common.acl.AclBinding;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class Main {
-
-  private static class AclEnforceCommand extends EnforceCommand<AclBinding> {
-    @Override
-    protected Enforcer<AclBinding> initEnforcer(AdminClient client) {
-      Json.addMixIns(MAPPER);
-      return new AclEnforcer(configuredEntities(AclBinding.class, "acls", "aclsFile"),
-          new AclService(client), !unsafemode, dryrun);
-    }
-  }
 
   @Parameter(
       names = {"--help", "-h"},

--- a/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/BaseCommand.java
+++ b/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/BaseCommand.java
@@ -51,13 +51,13 @@ public class BaseCommand<T> {
       description = "/path/to/a/configuration/file",
       required = true,
       converter = CommandConfigConverter.class)
-  private Map<String, Object> cmdConfig = null;
+  protected Map<String, Object> cmdConfig = null;
 
   @Parameter(
       names = {"--cluster"},
       description = "a cluster name, if specified, " +
           "consolidated (multi-cluster) configuration file is expected")
-  private String cluster = null;
+  protected String cluster = null;
 
   public BaseCommand() {
     // DO NOT REMOVE, this is needed by jcommander
@@ -165,5 +165,4 @@ public class BaseCommand<T> {
       return cmdConfig;
     }
   }
-
 }


### PR DESCRIPTION
Allows external uses of ACL command, e.g for validation of ACL configs