### PR TITLE
Freshness tracker should tolerate runtime exceptions when checking status

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
@@ -18,6 +18,7 @@ public class FreshnessMetrics {
   final Counter failed;
   final Counter invalid;
   final Counter error;
+  final Counter burrowClustersConsumersReadFailed;
   final Counter burrowClustersReadFailed;
   final Gauge freshness;
   final Histogram kafkaQueryLatency;
@@ -61,6 +62,11 @@ public class FreshnessMetrics {
         .name("kafka_consumer_freshness_runtime_query_exception")
         .help("Number of Kafka queries that threw an exception")
         .labelNames("cluster", "consumer")
+        .register();
+    burrowClustersConsumersReadFailed = new Counter.Builder()
+        .name("kafka_consumer_freshness_runtime_failed_burrow_cluster_consumers_read")
+        .help("Number of times we failed to lookup a cluster's consumers from burrow")
+        .labelNames("cluster")
         .register();
     burrowClustersReadFailed = new Counter.Builder()
         .name("kafka_consumer_freshness_runtime_failed_burrow_clusters_read")

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BUILD
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BUILD
@@ -27,6 +27,7 @@ java_test(
     name = "ConsumerFreshnessTest",
     srcs = ["ConsumerFreshnessTest.java"],
     deps = [
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
         "//3rdparty/jvm/junit",
         "//3rdparty/jvm/org/apache/kafka:kafka_clients",
         "//3rdparty/jvm/org/mockito:mockito_all",


### PR DESCRIPTION
Allows tracker to ride over bad consumer groups, clusters, and/or burrow reads