### PR TITLE
Reduce logging verbosity for some common messages

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessTracker.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessTracker.java
@@ -61,7 +61,7 @@ class FreshnessTracker implements Runnable {
         // producer or broker is only supposed to record non-negative timestamps, however
         // a non-standard client or client on a very old version may produce records with
         // negative timestamps -- we ignore those.
-        LOG.error("Read invalid offset for {} ({}) : {}", consumer.group, consumer.tp, entered.get());
+        LOG.info("Read invalid offset for {} ({}) : {}", consumer.group, consumer.tp, entered.get());
         metrics.invalid.labels(this.consumer.cluster, this.consumer.group).inc();
         return;
       }


### PR DESCRIPTION
We already track the issues via metrics, so the logging does not need to be quite so
verbose - listing every single topic/partition that can have a common error. This
can become particularly verbose when dealing with hundreds of consumers. Instead
this turns down the log levels so real errors can be more easily seen or are
summarized across all partitions (i.e. no partition has an end offset for the
consumer group, rather than listing potentially thousands of partitions).