### PR TITLE
Better error cause information when failing to reach burrow or kafka

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
@@ -91,7 +91,7 @@ class Burrow {
       // burrow will build a valid map with the body for invalid responses (i.e. consumer group not found), so we
       // need to check that the response was failure.
       if (!response.isSuccessful()) {
-        throw new IOException("Request was not successful");
+        throw new IOException("Response was not successful: " + response);
       }
       return MAPPER.readValue(response.body().byteStream(), Map.class);
     } catch (IOException e) {

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -156,7 +156,7 @@ public class ConsumerFreshness {
       try {
         clusters = burrow.getClusters();
       } catch (IOException e) {
-        LOG.error("Failed to read from burrow", e);
+        LOG.error("Failed to read clusters from burrow", e);
         this.metrics.burrowClustersReadFailed.inc();
         return null;
       }
@@ -198,7 +198,7 @@ public class ConsumerFreshness {
           status = client.getConsumerGroupStatus(consumerGroup);
           Preconditions.checkState(status.get("partitions") != null,
               "Burrow response is missing partitions, got {}", status);
-        } catch (JsonParseException | IllegalStateException e) {
+        } catch (IOException | IllegalStateException e) {
           // this happens sometimes, when burrow is acting up
           LOG.error("Failed to read Burrow status for consumer {}. Skipping", consumerGroup, e);
           metrics.error.labels(client.getCluster(), consumerGroup).inc();

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BurrowTest.java
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BurrowTest.java
@@ -5,6 +5,7 @@
 package com.tesla.data.consumer.freshness;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import tesla.shade.com.google.common.collect.Lists;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -92,6 +94,37 @@ public class BurrowTest {
     verify(client).newCall(expectPath("/v3/kafka"));
   }
 
+  @Test
+  public void testThrowExceptionOnUnsuccessfulResponse() {
+    OkHttpClient client = Mockito.mock(OkHttpClient.class);
+    Map<String, Object> response = new HashMap<>();
+    List<String> expected = Lists.newArrayList("c1", "c2");
+    response.put("clusters", expected);
+    when(client.newCall(any())).then(respondWithJson(response, 404));
+
+    Burrow burrow = new Burrow(CONF, client);
+    try {
+      burrow.getConsumerGroupStatus("mycluster", "mygroup");
+      fail("Should have thrown an exception when got a unsuccesful response");
+    } catch (IOException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFailGroupLookupWhenResponseIsNotAMap(){
+    OkHttpClient client = Mockito.mock(OkHttpClient.class);
+    when(client.newCall(any())).then(respondWithJson("foo-bar"));
+
+    Burrow burrow = new Burrow(CONF, client);
+    try {
+      burrow.getConsumerGroupStatus("mycluster", "mygroup");
+      fail("Should have thrown an exception when got a non-map type response");
+    } catch (IOException e) {
+      // expected
+    }
+  }
+
   private Request expectPath(String path) {
     return argThat(new BaseMatcher<Request>() {
       @Override
@@ -108,6 +141,10 @@ public class BurrowTest {
   }
 
   private Answer<Call> respondWithJson(Object o) {
+    return respondWithJson(o, 200);
+  }
+
+  private Answer<Call> respondWithJson(Object o, int code) {
     return new Answer<Call>() {
       @Override
       public Call answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -118,7 +155,7 @@ public class BurrowTest {
           Response response = new Response.Builder()
               .request(request)
               .body(body)
-              .code(200)
+              .code(code)
               .protocol(Protocol.HTTP_1_1)
               .message("Response")
               .build();

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/ConsumerFreshnessTest.java
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/ConsumerFreshnessTest.java
@@ -128,7 +128,7 @@ public class ConsumerFreshnessTest {
     Burrow.ClusterClient client = mockClusterState("cluster", "group");
     when(burrow.getClusters()).thenReturn(newArrayList(client));
     when(client.consumerGroups()).thenReturn(newArrayList("group"));
-    when(client.getConsumerGroupStatus("group")).thenThrow(mock(JsonParseException.class));
+    when(client.getConsumerGroupStatus("group")).thenThrow(mock(IOException.class));
     freshness.run();
     assertEquals(1.0, freshness.getMetricsForTesting().error.labels("cluster", "group").get(), 0.0);
   }


### PR DESCRIPTION
Freshness tracker previously had errors like:
```
2021-03-24 17:38:17 ERROR [main] c.t.d.c.f.ConsumerFreshness:159 - Failed to read from burrow
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('<' (code 60)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')
 at [Source: (okio.RealBufferedSource$1); line: 1, column: 2]
        at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1804)
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:663)
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:561)
```

Which made it hard to debug what calls were actually failing
when connecting to burrow. At the same time, we occasionally fail
to load the status for a consumer group; it could be just the consumer
group or it could just be burrow. Either way, we should check the return
result from the REST request and fail the consumer lookup; right now all
we have is a 'bare' NPE with no information as to the consumer group,
request or anything else.

Similar issues arrise when you have things like SSL errors when connecting
to Kafka (it just dumps the OutOfMemory error common to Kafka-SSL failures),
where you don't know the cluster or the consumer that particular lookup
failed at (though you can see the cluster and consumer failures in metrics,
having it in logs too is very helpful when debugging at 2am).