### PR TITLE
Updating freshness tests to cover explicit failure/access handling

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessTracker.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessTracker.java
@@ -87,7 +87,7 @@ class FreshnessTracker implements Runnable {
       });
     } catch (Throwable t) {
       LOG.error("Failed to read {} from Kafka - maybe an SSL/connectivity error?", consumer, t);
-      return Optional.empty();
+      throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
     }
   }
 

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BUILD
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BUILD
@@ -26,7 +26,12 @@ java_test(
 java_test(
     name = "ConsumerFreshnessTest",
     srcs = ["ConsumerFreshnessTest.java"],
+    resources = [
+        "//kafka_consumer_freshness_tracker/src/test/resources:test_deps",
+    ],
     deps = [
+        "//3rdparty/jvm/ch/qos/logback:logback_classic",
+        "//3rdparty/jvm/io/prometheus:simpleclient",
         "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
         "//3rdparty/jvm/junit",
         "//3rdparty/jvm/org/apache/kafka:kafka_clients",

--- a/kafka_consumer_freshness_tracker/src/test/resources/BUILD
+++ b/kafka_consumer_freshness_tracker/src/test/resources/BUILD
@@ -1,0 +1,6 @@
+filegroup(
+    name = "test_deps",
+    testonly = 1,
+    srcs = glob(["*"]),
+    visibility = ["//visibility:public"],
+)

--- a/kafka_consumer_freshness_tracker/src/test/resources/logback-test.xml
+++ b/kafka_consumer_freshness_tracker/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{20}:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="stdout"/>
+  </root>
+</configuration>


### PR DESCRIPTION
Adds more realistic test scenarios for existing tests (using a real threadpool and
mocking the Kafka interaction in the tracker), as well as explicitly covering the
various failure cases and how we handle them.

Also reverts the catching of KafkaConsumer exceptions in the FreshnessTracker, which
is how what would populate the per-consumer error metric.