### PR TITLE
Extract per-cluster and group freshness measurement

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -256,7 +256,7 @@ public class ConsumerFreshness {
 
     boolean anyEndOffsetFound = false;
     List<Map<String, Object>> partitions = (List<Map<String, Object>>) status.get("partitions");
-    List<ListenableFuture<Object>> partitionFreshnessComputation = new ArrayList<>(partitions.size());
+    List<ListenableFuture<?>> partitionFreshnessComputation = new ArrayList<>(partitions.size());
     for (Map<String, Object> state : partitions) {
       String topic = (String) state.get("topic");
       int partition = (int) state.get("partition");
@@ -268,15 +268,15 @@ public class ConsumerFreshness {
         continue;
       }
       anyEndOffsetFound = true;
-      long offset = Long.valueOf(end.get("offset").toString());
-      boolean upToDate = Long.valueOf(state.get("current_lag").toString()) == 0;
+      long offset = Long.parseLong(end.get("offset").toString());
+      boolean upToDate = Long.parseLong(state.get("current_lag").toString()) == 0;
       FreshnessTracker.ConsumerOffset consumerState =
           new FreshnessTracker.ConsumerOffset(burrow.getCluster(), consumerGroup, topic, partition, offset,
               upToDate);
 
       // wait for a consumer to become available
       KafkaConsumer consumer = workers.take();
-      ListenableFuture result = this.executor.submit(new FreshnessTracker(consumerState, consumer, metrics));
+      ListenableFuture<?> result = this.executor.submit(new FreshnessTracker(consumerState, consumer, metrics));
       // Hand back the consumer to the available workers when the task is complete
       Futures.addCallback(result, new FutureCallback<Object>() {
         @Override


### PR DESCRIPTION
This helps isolate the logic and error handling as the first
step to providing a clearer success/fail indicator per cluster.
Each cluster a single measurement that is waited upon (Future.get)
in the run loop. Each cluster Future waits on the completion of
each of the consumers in that cluster (itself a Future). Each
consumer Future is waiting on the completion of the FreshnessTracker
work for each partition.

That is, cluster = sum(consumer), consumer = sum(partitions).

Changes the behavior slightly for interruptions - they no longer
cause the burrowClustersConsumersReadFailed metric to increment,
which makes sense as that is not actually what failed (its actually
the interruption while waiting for an available KafkaConsumer).

Includes small tweaks to the tests as we use the executor pool
more aggressively now for handling per-consumer logic.