### PR TITLE
Close OkHttp responses when no longer used in freshness tracker

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
@@ -64,8 +64,7 @@ class Burrow {
     Request request = new Request.Builder()
         .url(PATHS.join(url, HEALTH_CHECK))
         .get().build();
-    try {
-      Response response = client.newCall(request).execute();
+    try (Response response = client.newCall(request).execute()) {
       return response.isSuccessful() && Objects.requireNonNull(response.body()).string().equals("GOOD");
     } catch (IOException e) {
       LOG.warn("Failed to execute the health check", e);
@@ -86,8 +85,9 @@ class Burrow {
     Request request = new Request.Builder()
         .url(url)
         .get().build();
-    try {
-      response = client.newCall(request).execute();
+    try (Response executed = client.newCall(request).execute()) {
+      // set separately so we have a hook outside in the finally block
+      response = executed;
       // burrow will build a valid map with the body for invalid responses (i.e. consumer group not found), so we
       // need to check that the response was failure.
       if (!response.isSuccessful()) {

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -14,6 +14,7 @@ import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.hotspot.DefaultExports;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,7 +92,9 @@ public class ConsumerFreshness {
         Request request = new Request.Builder()
             .url(String.format("http://localhost:%s/metrics", port))
             .get().build();
-        LOG.info(client.newCall(request).execute().body().string());
+        try (Response response = client.newCall(request).execute()) {
+          LOG.info(response.body().string());
+        }
         return;
       }
 


### PR DESCRIPTION
Sometimes in the logs we would see things like:
```
Jul 12, 2021 4:32:33 PM okhttp3.internal.platform.Platform log
ARNING: A connection to https://burrow.url/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
Jul 12, 2021 4:32:33 PM okhttp3.internal.platform.Platform log
WARNING: A connection to https://burrow.url/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
Jul 12, 2021 4:32:33 PM okhttp3.internal.platform.Platform log
```
which goes back to the burrow client not properly closing the
OkHttp response object.
Unfortunately, OkHttp makes it non-trivial to mock out the Response object
and there are no hooks to check to see if a response is closed  - just to
do the closing (and we cant do spy because the concrete impls are final
classes). So we just have to trust that the responses are closed.