### PR TITLE
Password generator should not include slashes

### DIFF
--- a/kafka_certificates/src/main/java/com/tesla/data/certificates/keystore/PasswordGenerator.java
+++ b/kafka_certificates/src/main/java/com/tesla/data/certificates/keystore/PasswordGenerator.java
@@ -15,7 +15,7 @@ public class PasswordGenerator {
   private static final int LOWERCASE_Z = 122;
   // a selection of special characters that should be nice to configurations
   private static final char[] SPECIAL_CHARS = new char[]{
-      '!', '#', '%', '&', '+', '-', '/', '\\', '(', ')', '*', '^', '=', '>', '<', ':', ';', ',', '.'
+      '!', '#', '%', '&', '+', '-', '(', ')', '*', '^', '=', '>', '<', ':', ';', ',', '.'
   };
 
   private final Random random;

--- a/kafka_certificates/src/test/java/com/tesla/data/certificates/keystore/PasswordGeneratorTest.java
+++ b/kafka_certificates/src/test/java/com/tesla/data/certificates/keystore/PasswordGeneratorTest.java
@@ -23,13 +23,13 @@ public class PasswordGeneratorTest {
     int len = 15;
     String pass = GENERATOR.generatePassword(len, 2, 2, 2, 2);
     assertEquals(len, pass.length());
-    assertContainsAll(pass, "J", "L", ".", ":");
+    assertContainsAll(pass, "J", "L", "+", "*");
 
     // do it again, but should be different b/c of randomness in some letters + scrambling
     PasswordGenerator gen = new PasswordGenerator(new Random(SEED));
     String pass2 = gen.generatePassword(len, 2, 2, 2, 2);
     assertEquals(len, pass2.length());
-    assertContainsAll(pass2, "J", "L", ".", ":");
+    assertContainsAll(pass2, "J", "L", "+", "*");
     assertNotEquals("Generated the same password twice", pass, pass2);
   }
 


### PR DESCRIPTION
Ends up not playing nice when loading into strings in Java as they need to
be escaped. There are plenty of other 'good' special characters left to use,
so not a big risk to remove these in terms of randomness.

Test needs to be fixed because the range of characters to pick from is different,
leading to different items being selected from the list.