### PR TITLE
Add a metric to track kafka record timestamp type

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessMetrics.java
@@ -20,6 +20,7 @@ public class FreshnessMetrics {
   final Counter error;
   final Counter burrowClustersConsumersReadFailed;
   final Counter burrowClustersReadFailed;
+  final Counter timestampType;
   final Gauge freshness;
   final Histogram kafkaQueryLatency;
   final Gauge lastClusterRunAttempt;
@@ -71,6 +72,11 @@ public class FreshnessMetrics {
     burrowClustersReadFailed = new Counter.Builder()
         .name("kafka_consumer_freshness_runtime_failed_burrow_clusters_read")
         .help("Number of times we failed to lookup the clusters from burrow")
+        .register();
+    timestampType = new Counter.Builder()
+        .name("kafka_consumer_freshness_runtime_timestamp_type")
+        .help("Counter to track kafka record timestamp type (CreateTime, LogAppendTime)")
+        .labelNames("cluster", "topic", "type")
         .register();
     freshness = new Gauge.Builder()
         .name("kafka_consumer_freshness_ms")

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/FreshnessTrackerTest.java
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/FreshnessTrackerTest.java
@@ -17,6 +17,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -91,6 +92,7 @@ public class FreshnessTrackerTest {
 
     assertEquals("Should be behind the LEO timestamp", 1,
         metrics.freshness.labels("cluster", "group", "topic", "1").get(), 0);
+    assertEquals(1, metrics.timestampType.labels("cluster", "topic", "LogAppendTime").get(), 0);
     assertEquals(0, metrics.failed.labels("cluster", "group").get(), 0);
     TopicPartition tp = new TopicPartition("topic", 1);
     Collection<TopicPartition> tps = Collections.singletonList(tp);
@@ -163,6 +165,7 @@ public class FreshnessTrackerTest {
     for (long ts : timestamps) {
       ConsumerRecord record = mock(ConsumerRecord.class);
       when(record.timestamp()).thenReturn(ts);
+      when(record.timestampType()).thenReturn(TimestampType.LOG_APPEND_TIME);
       consumerRecords.add(record);
     }
     Map<TopicPartition, List<ConsumerRecord>> map = new HashMap<>();


### PR DESCRIPTION
Freshness tracker uses kafka record timestamp to determine
when the event may have entered our system. This timestamp can
be set in two ways

(a) A producer can set it, in which case the timestamp type is createtime
(b) Broker can set it, in which case the timestamp type is logappendtime

An edge case for freshness tracker is when producer sets the timestamp and
producer's clock is out of sync, in such case, freshness tracker will be
mislead into detecting a lag since it uses current system time (tracker's).

This change adds a new metric to track timestamp types. It doesn't do much
to avoid the false detection, but provides visibility to debug the issue further.