### PR TITLE
Log unexpected entities if safemode is on

### DIFF
--- a/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/Enforcer.java
+++ b/kafka_enforcer_common/src/main/java/com/tesla/data/enforcer/Enforcer.java
@@ -157,6 +157,14 @@ public abstract class Enforcer<T> {
     alterDrifted();
     if (!safemode) {
       deleteUnexpected();
+    } else {
+      List<T> toDelete = unexpected();
+      if (!toDelete.isEmpty()) {
+        LOG.info("Found {} redundant entities: {}", toDelete.size(), toDelete);
+        LOG.info("Unexpected entities were not removed because safemode is on.");
+      } else {
+        LOG.info("No un-expected entity was found.");
+      }
     }
     LOG.info("\n--Enforcement run ended--");
   }


### PR DESCRIPTION
These get logged when safemode is off (and the enforcer will subsequently delete them) but it's hard to debug which entities are unexpected when safemode is on.