### PR TITLE
Fix parsing of Burrow get cluster detail response

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
@@ -120,13 +120,10 @@ class Burrow {
   public List<String> getClusterBootstrapServers(String cluster) throws IOException {
     final Map<String, Object> response = this.request(cluster);
 
-    final Map<String, Object> module = (Map<String, Object>) response.get("module");
-    Preconditions.checkArgument(module != null,
+    final Map<String, Object> module = (Map<String, Object>) Preconditions.checkNotNull(response.get("module"),
             "response doesn't contain `module`: Response" + response);
 
-    List<String> servers = (List<String>) module.get("servers");
-
-    Preconditions.checkArgument(servers != null,
+    List<String> servers = (List<String>) Preconditions.checkNotNull(module.get("servers"),
             "response doesn't contain `module.servers`: Response" + response);
     return servers;
   }

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
@@ -12,6 +12,7 @@ import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tesla.shade.com.google.common.base.Joiner;
+import tesla.shade.com.google.common.base.Preconditions;
 import tesla.shade.com.google.common.collect.Lists;
 
 import java.io.IOException;
@@ -118,14 +119,15 @@ class Burrow {
 
   public List<String> getClusterBootstrapServers(String cluster) throws IOException {
     final Map<String, Object> response = this.request(cluster);
+
     final Map<String, Object> module = (Map<String, Object>) response.get("module");
-    if (module == null) {
-      throw new IOException("response doesn't contain `module`: Response" + response);
-    }
+    Preconditions.checkArgument(module != null,
+            "response doesn't contain `module`: Response" + response);
+
     List<String> servers = (List<String>) module.get("servers");
-    if (servers == null) {
-      throw new IOException("response doesn't contain `module.servers`: Response" + response);
-    }
+
+    Preconditions.checkArgument(servers != null,
+            "response doesn't contain `module.servers`: Response" + response);
     return servers;
   }
 

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
@@ -118,9 +118,15 @@ class Burrow {
 
   public List<String> getClusterBootstrapServers(String cluster) throws IOException {
     final Map<String, Object> response = this.request(cluster);
-    final Map<String, Object> clusterDetail = (Map<String, Object>) response.get("cluster");
-    final Map<String, Object> module = (Map<String, Object>) clusterDetail.get("module");
-    return (List<String>) module.get("servers");
+    final Map<String, Object> module = (Map<String, Object>) response.get("module");
+    if (module == null) {
+      throw new IOException("response doesn't contain `module`: Response" + response);
+    }
+    List<String> servers = (List<String>) module.get("servers");
+    if (servers == null) {
+      throw new IOException("response doesn't contain `module.servers`: Response" + response);
+    }
+    return servers;
   }
 
   public class ClusterClient {

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BurrowTest.java
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BurrowTest.java
@@ -127,10 +127,8 @@ public class BurrowTest {
     List<String> expected = Lists.newArrayList("kafka01.example.com:10251", "kafka02.example.com:10251");
     Map<String, List<String>> module = new HashMap<>();
     module.put("servers", expected);
-    Map<String, Object> cluster = new HashMap<>();
-    cluster.put("module",module);
     Map<String, Object> response = new HashMap<>();
-    response.put("cluster", cluster);
+    response.put("module",module);
     when(client.newCall(any())).then(respondWithJson(response));
 
     Burrow burrow = new Burrow(CONF, client);

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BurrowTest.java
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/BurrowTest.java
@@ -128,7 +128,7 @@ public class BurrowTest {
     Map<String, List<String>> module = new HashMap<>();
     module.put("servers", expected);
     Map<String, Object> response = new HashMap<>();
-    response.put("module",module);
+    response.put("module", module);
     when(client.newCall(any())).then(respondWithJson(response));
 
     Burrow burrow = new Burrow(CONF, client);


### PR DESCRIPTION
Noticed when testing in staging that contrary to the Burrow [API documentation](https://github.com/linkedin/Burrow/wiki/http-request-kafka-cluster-detail), the response to a cluster detail call does not contain a `cluster` object containing a `module` object but rather, the `module` object is at the top-level.

This PR fixes the response parsing logic (and associated testing) to reflect this.