### PR TITLE
Improve freshness verbosity

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
@@ -92,7 +92,7 @@ class Burrow {
       // burrow will build a valid map with the body for invalid responses (i.e. consumer group not found), so we
       // need to check that the response was failure.
       if (!response.isSuccessful()) {
-        throw new IOException("Response was not successful: " + response);
+        throw new UnsuccessfulResponseException(response);
       }
       return MAPPER.readValue(response.body().byteStream(), Map.class);
     } catch (IOException e) {
@@ -146,6 +146,18 @@ class Burrow {
 
     public String getCluster() {
       return cluster;
+    }
+  }
+
+  /**
+   * Exception when the request returned unsuccessfully.
+   */
+  public class UnsuccessfulResponseException extends IOException {
+    public final Response response;
+
+    public UnsuccessfulResponseException(Response response) {
+      super("Response was not successful: " + response);
+      this.response = response;
     }
   }
 }

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
@@ -82,7 +82,7 @@ class Burrow {
   private Map<String, Object> request(String... paths) throws IOException {
     Response response = null;
     HttpUrl url = address(paths);
-    LOG.debug("GET {}", url);
+    LOG.trace("GET {}", url);
     Request request = new Request.Builder()
         .url(url)
         .get().build();

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -383,6 +383,7 @@ public class ConsumerFreshness {
         @Override
         public PartitionResult call() {
           try {
+            LOG.debug("Calculating freshness for {}", consumerState);
             tracker.run();
             return new PartitionResult(consumerState);
           } catch (Exception e) {

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessTracker.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/FreshnessTracker.java
@@ -70,6 +70,12 @@ class FreshnessTracker implements Runnable {
       }
       Instant now = Instant.now(clock);
       freshness = Math.max(now.toEpochMilli() - record.timestamp(), 0);
+      LOG.debug("Found freshness of {} from first uncommitted record {} for {}", freshness, record, consumer);
+    } else {
+      // up-to-date consumers are at the LEO (i.e. lag == 0), so we don't have a 'first uncommitted record' that
+      // would be interesting to log, so just log the freshness == 0. Its in an 'else' to avoid too double logging
+      // for consumers that are not up-to-date.
+      LOG.debug("{} recording {} ms freshness", consumer, freshness);
     }
     metrics.freshness.labels(this.consumer.cluster, this.consumer.group, this.from.topic(),
         Integer.toString(this.from.partition()))


### PR DESCRIPTION
For burrow 404 errors, we avoid dumping the entire stack trace, but instead just log the exception message and move along. This dramatically cuts down log verbosity during normal operations, allowing the operator to see 'real' errors.

For when things get wonky, we need a way to see what the freshness tracker is using to calculate freshness - the current consumer state and the 'next' record against which freshness is calculated. Putting this at DEBUG lets us see what is happening, albeit with high degree of verbosity (most folks should not run at DEBUG normally though, this is just for debugging persistent tracker issues).

Addresses #59 