### PR TITLE
Burrow should not log unsuccessful request stack traces

### DIFF
--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/Burrow.java
@@ -95,6 +95,9 @@ class Burrow {
         throw new UnsuccessfulResponseException(response);
       }
       return MAPPER.readValue(response.body().byteStream(), Map.class);
+    } catch (UnsuccessfulResponseException e){
+      // we generated this exception ourselves, don't need to log it like "real" IOExceptions
+      throw e;
     } catch (IOException e) {
       // ensure to log the response (which includes the request) for debugging purposes, its not usually going to be
       // included in the error message


### PR DESCRIPTION
That is, requests that complete but have a non-200 REST response code
are not logged at ERROR along with a stack trace. We already log the
error in the caller (ConsumerFreshness) and these burrow errors are
common enough and failed REST responses dont need full stack traces
to determine the eerror - in fact, the stack trace can often just add
noise to the log.

Example log messages + stack trace that we are trying to avoid:
```
2022-07-10 06:37:31 ERROR [main] c.t.d.c.f.Burrow:101 - Failed to complete request:Response{protocol=http/1.1, code=404, message=Not Found, url=http://burrow.cloud/v3/kafka/my-kafka/consumer/example_consumer/lag}
com.tesla.data.consumer.freshness.Burrow$UnsuccessfulResponseException: Response was not successful: Response{protocol=http/1.1, code=404, message=Not Found, url=http://burrow.cloud/v3/kafka/my-kafka/consumer/example_consumer/lag}
        at com.tesla.data.consumer.freshness.Burrow.request(Burrow.java:95)
        at com.tesla.data.consumer.freshness.Burrow.getConsumerGroupStatus(Burrow.java:111)
        at com.tesla.data.consumer.freshness.Burrow$ClusterClient.getConsumerGroupStatus(Burrow.java:144)
        at com.tesla.data.consumer.freshness.ConsumerFreshness.measureConsumer(ConsumerFreshness.java:339)
        at com.tesla.data.consumer.freshness.ConsumerFreshness.measureCluster(ConsumerFreshness.java:273)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.stream.ReferencePipeline$11$1.accept(ReferencePipeline.java:440)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
        at java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
        at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool.helpComplete(ForkJoinPool.java:1870)
        at java.util.concurrent.ForkJoinPool.externalHelpComplete(ForkJoinPool.java:2467)
        at java.util.concurrent.ForkJoinTask.externalAwaitDone(ForkJoinTask.java:324)
        at java.util.concurrent.ForkJoinTask.doInvoke(ForkJoinTask.java:405)
        at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:734)
        at java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:159)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:173)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
        at com.tesla.data.consumer.freshness.ConsumerFreshness.lambda$run$6(ConsumerFreshness.java:236)
        at io.prometheus.client.Summary$Child.time(Summary.java:228)
        at io.prometheus.client.Summary.time(Summary.java:335)
        at com.tesla.data.consumer.freshness.ConsumerFreshness.run(ConsumerFreshness.java:216)
        at com.tesla.data.consumer.freshness.ConsumerFreshness.main(ConsumerFreshness.java:113)
2022-07-10 06:37:32 ERROR [ForkJoinPool.commonPool-worker-0] c.t.d.c.f.ConsumerFreshness:346 - Failed to read Burrow status for consumer example_consumer. Skipping
Response was not successful: Response{protocol=http/1.1, code=404, message=Not Found, url=http://burrow.cloud/v3/kafka/my-kafka/consumer/example_consumer/lag}
```