### PR TITLE
Support customized command start-cmd for service start with kafka_roller.

### DIFF
--- a/kafka_roller/README.md
+++ b/kafka_roller/README.md
@@ -48,6 +48,7 @@ Options:
   -h INT, --healthcheck-retries=INT   health check retries before aborting
   -p STRING, --pre-stop=STRING        command to run on each host before stopping the service
   -r STRING, --pre-start=STRING       command to run on each host before starting the service
+  -s STRING, --start-cmd=STRING       customized command for starting the service
   -z STRING, --zk=STRING              zookeeper used by kafka
 ```
 

--- a/kafka_roller/kafka_roller/tasks.py
+++ b/kafka_roller/kafka_roller/tasks.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
         "conf": "kafka admin config overrides in a json file",
         "pre_stop": "command to run on each host before stopping the service",
         "pre_start": "command to run on each host before starting the service",
+        "start_cmd": "customized command for starting the service",
     }
 )
 def restart(
@@ -41,6 +42,7 @@ def restart(
     conf=None,
     pre_stop=None,
     pre_start=None,
+    start_cmd=None,
 ):
     """Gracefully restart an instance."""
     admin = _admin_client(bootstrap, conf)
@@ -57,20 +59,20 @@ def restart(
         logger.info("(%s/%s) Restarting %s", index + 1, len(hosts), hostname(b.host))
         start = datetime.now()
         _instance_restart(
-            b, admin, zk, healthcheck_retries, healthcheck_wait, pre_stop, pre_start
+            b, admin, zk, healthcheck_retries, healthcheck_wait, pre_stop, pre_start, start_cmd
         )
         end = datetime.now()
         logger.info("Instance restart took: %s", end - start)
 
 
-def _instance_restart(c, admin, zk, retries, retry_wait, pre_stop, pre_start):
+def _instance_restart(c, admin, zk, retries, retry_wait, pre_stop, pre_start, start_cmd):
     """Gracefully restart an instance."""
     with ZK(zk) as zk_conn:
         if not is_cluster_healthy(admin, zk_conn, retries, retry_wait):
             logger.critical("Cluster is not healthy, aborting!")
             sys.exit(1)
         stop(c, pre_stop)
-        start(c, pre_start)
+        start(c, pre_start, start_cmd)
 
 
 def _admin_client(bootstrap, conf=None):
@@ -103,11 +105,14 @@ def stop(c, pre_stop=None):
     # introduce & execute post stop here if needed..
 
 
-def start(c, pre_start=None):
+def start(c, pre_start=None, start_cmd=None):
     """Gracefully start an instance."""
     if pre_start is not None:
         _run_safe(c, "Pre-start", pre_start)
-    service_start(c, "kafka")
+    if start_cmd is not None:
+        _run_safe(c, "Start", start_cmd)
+    else:
+        service_start(c, "kafka")
     # introduce & execute post start here if needed..
 
 


### PR DESCRIPTION
There are times we need to use a different command than `service kafka start` such as `reboot` or some command that manipulate the VM. This feature allows to specify this behavior instead of using the default service start.