### PR TITLE
Update Java version used by CI to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '8.0.265'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Setup bin directory
         run: |
@@ -22,7 +23,7 @@ jobs:
 
       - name: Setup build dependencies
         run: |
-          wget https://github.com/bazelbuild/bazelisk/releases/download/v1.6.0/bazelisk-linux-amd64
+          wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
           chmod +x bazelisk-linux-amd64
           mv bazelisk-linux-amd64 $HOME/bin/bazelisk
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The tools are written in Java & Python. Refer to language specific section for d
 
 ## Java
 
+Kafka Helmsman is built and tested using Java 17.
+
 ### Dependencies
 
 Java code uses [bazel](https://www.bazel.build) as the build tool, installation of which is managed via bazelisk. Bazelisk is a version manager for Bazel. It takes care of downloading and installing Bazel itself, so you don’t have to worry about using the correct version of Bazel.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The tools are written in Java & Python. Refer to language specific section for d
 
 ## Java
 
-Kafka Helmsman is built and tested using Java 17.
+Kafka Helmsman is built and tested using Java 17. Bazel hermetically fetches a Java 17 distribution and uses it to compile the code and run tests.
+User environments only require the minimum Java version required for running Bazel itself (currently Java 8).
 
 ### Dependencies
 


### PR DESCRIPTION
Note that this JDK/JRE on host is only used for running Bazel itself, not for building or testing code. The JDK/JRE used for building and testing is hermetically fetched by Bazel. Mention reliance on Java 17 in the project README.