### PR TITLE
Clean up dead code in topic enforcer around listing existing topics.

### DIFF
--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/DumpCommand.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/DumpCommand.java
@@ -24,7 +24,7 @@ public class DumpCommand extends BaseCommand<ConfiguredTopic> {
   public int run() {
     try (AdminClient kafka = KafkaAdminClient.create(kafkaConfig())) {
       TopicService topicService = new TopicServiceImpl(kafka, true);
-      Collection<ConfiguredTopic> existing = topicService.listExisting(true).values()
+      Collection<ConfiguredTopic> existing = topicService.listExisting().values()
           .stream()
           .sorted(Comparator.comparing(ConfiguredTopic::getName))
           .collect(Collectors.toList());

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/TopicEnforcer.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/TopicEnforcer.java
@@ -54,7 +54,7 @@ public class TopicEnforcer extends Enforcer<ConfiguredTopic> {
       boolean safemode) {
     super(
         configuredTopics,
-        () -> topicService.listExisting(true).values(),
+        () -> topicService.listExisting().values(),
         (t1, t2) -> t1.getName().equals(t2.getName()),
         safemode);
     checkArgument(
@@ -88,7 +88,7 @@ public class TopicEnforcer extends Enforcer<ConfiguredTopic> {
     if (this.configured.isEmpty()) {
       return Collections.emptyList();
     }
-    Map<String, ConfiguredTopic> existing = this.topicService.listExisting(true);
+    Map<String, ConfiguredTopic> existing = this.topicService.listExisting();
     return Collections.unmodifiableList(
         this.configured.stream()
             .filter(t -> existing.containsKey(t.getName()))

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/TopicService.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/TopicService.java
@@ -19,10 +19,9 @@ public interface TopicService {
   /**
    * Load existing topics from a kafka cluster.
    *
-   * @param excludeInternal if true kafka internal topics are excluded
    * @return a collection of topics.
    */
-  Map<String, ConfiguredTopic> listExisting(boolean excludeInternal);
+  Map<String, ConfiguredTopic> listExisting();
 
   /**
    * Create new topics.

--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/TopicServiceImpl.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/TopicServiceImpl.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutionException;
 
 public class TopicServiceImpl implements TopicService {
 
-  private static final ListTopicsOptions INCLUDE_INTERNAL = new ListTopicsOptions().listInternal(true);
   private static final ListTopicsOptions EXCLUDE_INTERNAL = new ListTopicsOptions().listInternal(false);
   private final AdminClient adminClient;
   private final boolean dryRun;
@@ -94,11 +93,9 @@ public class TopicServiceImpl implements TopicService {
   }
 
   @Override
-  public Map<String, ConfiguredTopic> listExisting(boolean excludeInternal) {
+  public Map<String, ConfiguredTopic> listExisting() {
     try {
-      Set<String> topics = adminClient
-          .listTopics(excludeInternal ? EXCLUDE_INTERNAL : INCLUDE_INTERNAL)
-          .names().get();
+      Set<String> topics = adminClient.listTopics(EXCLUDE_INTERNAL).names().get();
       Collection<TopicDescription> topicDescriptions = adminClient.describeTopics(topics).all().get().values();
 
       List<ConfigResource> resources = topics

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/TopicEnforcerTest.java
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/TopicEnforcerTest.java
@@ -61,13 +61,13 @@ public class TopicEnforcerTest {
         "d", new ConfiguredTopic("b", 1, (short) 1, Collections.emptyMap())
     );
 
-    when(service.listExisting(true)).thenReturn(existing);
+    when(service.listExisting()).thenReturn(existing);
     TopicEnforcer enforcer = new TopicEnforcer(service, configured, true);
     enforcer.increasePartitions();
 
     // topic 'b' and 'c' should be subject to config alteration
     List<ConfiguredTopic> expected = Arrays.asList(configured.get(1), configured.get(2));
-    verify(service).listExisting(true);
+    verify(service).listExisting();
     verify(service).increasePartitions(expected);
     verifyNoMoreInteractions(service);
   }
@@ -91,13 +91,13 @@ public class TopicEnforcerTest {
         "d", new ConfiguredTopic("d", 1, (short) 1, Collections.singletonMap("k", "v"))
     );
 
-    when(service.listExisting(true)).thenReturn(existing);
+    when(service.listExisting()).thenReturn(existing);
     TopicEnforcer enforcer = new TopicEnforcer(service, configured, true);
     enforcer.alterConfiguration();
 
     // topic 'a' and 'd' should be subject to config alteration
     List<ConfiguredTopic> expected = Arrays.asList(configured.get(0), configured.get(3));
-    verify(service).listExisting(true);
+    verify(service).listExisting();
     verify(service).alterConfiguration(expected);
     verifyNoMoreInteractions(service);
   }
@@ -108,7 +108,7 @@ public class TopicEnforcerTest {
         new ConfiguredTopic("a", 1000, (short) 3, Collections.emptyMap()));
     Map<String, ConfiguredTopic> existing = Collections.singletonMap("a",
         new ConfiguredTopic("a", 100, (short) 3, Collections.emptyMap()));
-    when(service.listExisting(true)).thenReturn(existing);
+    when(service.listExisting()).thenReturn(existing);
     enforcer = new TopicEnforcer(service, configured, false);
     Assert.assertEquals("aggressive partition count increase must be allowed in unsafe mode", configured,
         enforcer.increasePartitions());
@@ -121,7 +121,7 @@ public class TopicEnforcerTest {
         new ConfiguredTopic("a", 10, (short) 3, risky));
     Map<String, ConfiguredTopic> existing = Collections.singletonMap("a",
         new ConfiguredTopic("a", 10, (short) 3, Collections.emptyMap()));
-    when(service.listExisting(true)).thenReturn(existing);
+    when(service.listExisting()).thenReturn(existing);
 
     // attempt a risk config change, it should go through
     enforcer = new TopicEnforcer(service, configured,

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/TopicServiceImplTest.java
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/TopicServiceImplTest.java
@@ -122,7 +122,7 @@ public class TopicServiceImplTest {
     when(adminClient.describeTopics(topicNames)).thenReturn(describeTopicsResult);
     when(adminClient.describeConfigs(any(Collection.class))).thenReturn(describeConfigsResult);
 
-    Map<String, ConfiguredTopic> actual = service.listExisting(true);
+    Map<String, ConfiguredTopic> actual = service.listExisting();
     Assert.assertEquals(2, actual.size());
     Assert.assertEquals(new HashSet<>(Arrays.asList("a", "b")), actual.keySet());
   }


### PR DESCRIPTION
Topic Enforcer lists existing topics with an optional filter to exclude internal topics from enforcement. It was intended to be a switch to allow including internal topics in the results. However, we have never included internal topics for the enforcer, and the current listing code does not work for that logic either -- even if we include internal topics in the Kafka admin client call, the internal topics are still filtered out at the step when we returns.

Given we are not using this include-internal logic, let's just remove it and clean up.