### PR TITLE
Use double instead of integers for Kafka quota values.

### DIFF
--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/ConfiguredQuota.java
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/ConfiguredQuota.java
@@ -16,14 +16,14 @@ public class ConfiguredQuota {
   private final String principal;
   private final String client;
   @JsonProperty("producer-byte-rate")
-  private final Integer producerByteRate;
+  private final Double producerByteRate;
   @JsonProperty("consumer-byte-rate")
-  private final Integer consumerByteRate;
+  private final Double consumerByteRate;
   @JsonProperty("request-percentage")
-  private final Integer requestPercentage;
+  private final Double requestPercentage;
 
-  public ConfiguredQuota(String principal, String client, Integer producerByteRate,
-                         Integer consumerByteRate, Integer requestPercentage) {
+  public ConfiguredQuota(String principal, String client, Double producerByteRate,
+                         Double consumerByteRate, Double requestPercentage) {
     Preconditions.checkArgument(principal != null || client != null, "Invalid quota configuration detected. " +
         "At least one of 'principal' or 'client' must be provided.");
     this.principal = principal;
@@ -41,15 +41,15 @@ public class ConfiguredQuota {
     return client;
   }
 
-  public Integer getProducerByteRate() {
+  public Double getProducerByteRate() {
     return producerByteRate;
   }
 
-  public Integer getConsumerByteRate() {
+  public Double getConsumerByteRate() {
     return consumerByteRate;
   }
 
-  public Integer getRequestPercentage() {
+  public Double getRequestPercentage() {
     return requestPercentage;
   }
 

--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/QuotaService.java
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/QuotaService.java
@@ -88,9 +88,9 @@ public class QuotaService {
 
   private ConfiguredQuota configuredQuota(Map.Entry<String, Properties> quotaEntry, EntityType entityType) {
     Properties quota = quotaEntry.getValue();
-    Integer producerByteRate = getQuotaValue(quota, PRODUCER_BYTE_RATE);
-    Integer consumerByteRate = getQuotaValue(quota, CONSUMER_BYTE_RATE);
-    Integer requestPercentage = getQuotaValue(quota, REQUEST_PERCENTAGE);
+    Double producerByteRate = getQuotaValue(quota, PRODUCER_BYTE_RATE);
+    Double consumerByteRate = getQuotaValue(quota, CONSUMER_BYTE_RATE);
+    Double requestPercentage = getQuotaValue(quota, REQUEST_PERCENTAGE);
 
     switch (entityType) {
       case PRINCIPAL:
@@ -144,7 +144,7 @@ public class QuotaService {
   /**
    * Return the quota value if it exists in the properties, or null if it does not exist.
    */
-  private Integer getQuotaValue(Properties quota, String quotaType) {
-    return quota.get(quotaType) != null ? Integer.valueOf(quota.getProperty(quotaType)) : null;
+  private Double getQuotaValue(Properties quota, String quotaType) {
+    return quota.get(quotaType) != null ? Double.valueOf(quota.getProperty(quotaType)) : null;
   }
 }

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/BUILD
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/BUILD
@@ -29,6 +29,7 @@ java_test(
     ],
     deps = [
         "//3rdparty/jvm/org/mockito:mockito_core",
+        "//kafka_enforcer_common/src/main/java/com/tesla/data/enforcer",
         "//kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer",
     ],
 )

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/ConfiguredQuotaTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/ConfiguredQuotaTest.java
@@ -13,17 +13,17 @@ public class ConfiguredQuotaTest {
   public void testBadConfiguration() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid quota configuration detected. At least one of 'principal' or 'client' must be provided.");
-    new ConfiguredQuota(null, null, 5000., 4000., 50.);
+    new ConfiguredQuota(null, null, 5000d, 4000d, 50d);
   }
 
   @Test
   public void testConfiguredQuotaEquals() {
-    ConfiguredQuota quota = new ConfiguredQuota("user1", "clientA", 2000., 1000., 50.);
-    Assert.assertEquals(quota, new ConfiguredQuota("user1", "clientA", 2000., 1000., 50.));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("badUser", "clientA", 2000., 1000., 50.));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "badClient", 2000., 1000., 50.));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 9999., 1000., 50.));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000., 9999., 50.));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000., 1000., 99.));
+    ConfiguredQuota quota = new ConfiguredQuota("user1", "clientA", 2000d, 1000d, 50d);
+    Assert.assertEquals(quota, new ConfiguredQuota("user1", "clientA", 2000d, 1000d, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("badUser", "clientA", 2000d, 1000d, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "badClient", 2000d, 1000d, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 9999d, 1000d, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000d, 9999d, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000d, 1000d, 99d));
   }
 }

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/ConfiguredQuotaTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/ConfiguredQuotaTest.java
@@ -13,17 +13,17 @@ public class ConfiguredQuotaTest {
   public void testBadConfiguration() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid quota configuration detected. At least one of 'principal' or 'client' must be provided.");
-    new ConfiguredQuota(null, null, 5000, 4000, 50);
+    new ConfiguredQuota(null, null, 5000., 4000., 50.);
   }
 
   @Test
   public void testConfiguredQuotaEquals() {
-    ConfiguredQuota quota = new ConfiguredQuota("user1", "clientA", 2000, 1000, 50);
-    Assert.assertEquals(quota, new ConfiguredQuota("user1", "clientA", 2000, 1000, 50));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("badUser", "clientA", 2000, 1000, 50));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "badClient", 2000, 1000, 50));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 9999, 1000, 50));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000, 9999, 50));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000, 1000, 99));
+    ConfiguredQuota quota = new ConfiguredQuota("user1", "clientA", 2000., 1000., 50.);
+    Assert.assertEquals(quota, new ConfiguredQuota("user1", "clientA", 2000., 1000., 50.));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("badUser", "clientA", 2000., 1000., 50.));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "badClient", 2000., 1000., 50.));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 9999., 1000., 50.));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000., 9999., 50.));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000., 1000., 99.));
   }
 }

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/ConfiguredQuotaTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/ConfiguredQuotaTest.java
@@ -1,9 +1,16 @@
 package com.tesla.data.quota.enforcer;
 
+import com.tesla.data.enforcer.BaseCommand;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 
 public class ConfiguredQuotaTest {
   @Rule
@@ -25,5 +32,31 @@ public class ConfiguredQuotaTest {
     Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 9999d, 1000d, 50d));
     Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000d, 9999d, 50d));
     Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000d, 1000d, 99d));
+  }
+
+  @Test
+  public void testConverter() throws Exception {
+    String cfg = String.join("\n",
+        "---",
+        "kafka:",
+        "    bootstrap.servers: localhost:9092",
+        "quota:",
+        "    - principal: user1",
+        "      client: float-client",
+        "      producer-byte-rate: 2000.0",
+        "      consumer-byte-rate: 1000.0",
+        "      request-percentage: 52.7",
+        "    - principal: backward-compatible",
+        "      client: all-integers",
+        "      producer-byte-rate: 2000",
+        "      consumer-byte-rate: 1000",
+        "      request-percentage: 50");
+    final BaseCommand.CommandConfigConverter converter = new BaseCommand.CommandConfigConverter();
+    Map<String, Object> config = converter.convert(new ByteArrayInputStream(cfg.getBytes(StandardCharsets.UTF_8)));
+    List<ConfiguredQuota> quotas =
+        new BaseCommand<ConfiguredQuota>(config).configuredEntities(ConfiguredQuota.class, "quota", "quotaFile");
+    Assert.assertEquals(quotas, List.of(
+        new ConfiguredQuota("user1", "float-client", 2000d, 1000d, 52.7),
+        new ConfiguredQuota("backward-compatible", "all-integers", 2000d, 1000d, 50d)));
   }
 }

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaEnforcerTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaEnforcerTest.java
@@ -19,8 +19,8 @@ public class QuotaEnforcerTest {
 
   private QuotaService quotaService;
   private static final List<ConfiguredQuota> quotas = Arrays.asList(
-      new ConfiguredQuota("user1", "clientA", 5000, 4000, 100),
-      new ConfiguredQuota("<default>", null, 6000, 3000, null)
+      new ConfiguredQuota("user1", "clientA", 5000., 4000., 100.),
+      new ConfiguredQuota("<default>", null, 6000., 3000., null)
   );
 
   @Before

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaEnforcerTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaEnforcerTest.java
@@ -19,8 +19,8 @@ public class QuotaEnforcerTest {
 
   private QuotaService quotaService;
   private static final List<ConfiguredQuota> quotas = Arrays.asList(
-      new ConfiguredQuota("user1", "clientA", 5000., 4000., 100.),
-      new ConfiguredQuota("<default>", null, 6000., 3000., null)
+      new ConfiguredQuota("user1", "clientA", 5000d, 4000d, 100d),
+      new ConfiguredQuota("<default>", null, 6000d, 3000d, null)
   );
 
   @Before

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaServiceTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaServiceTest.java
@@ -42,7 +42,7 @@ public class QuotaServiceTest {
     existingUserClientQuotas.put("user1/clients/client1", user1Client1Props);
 
     Properties defaultUserDefaultClient = new Properties();
-    defaultUserDefaultClient.put("producer_byte_rate", "200");
+    defaultUserDefaultClient.put("producer_byte_rate", "200.0");
     defaultUserDefaultClient.put("consumer_byte_rate", "500");
     defaultUserDefaultClient.put("request_percentage", "80");
     existingUserClientQuotas.put("<default>/clients/<default>", defaultUserDefaultClient);
@@ -79,11 +79,11 @@ public class QuotaServiceTest {
     Map<String, Properties> existingClientQuotas = new HashMap<>();
     Properties client1Props = new Properties();
     client1Props.put("producer_byte_rate", "150");
-    client1Props.put("request_percentage", "200");
+    client1Props.put("request_percentage", "200.0");
     existingClientQuotas.put("client1", client1Props);
 
     Properties defaultClientProps = new Properties();
-    defaultClientProps.put("producer_byte_rate", "5000");
+    defaultClientProps.put("producer_byte_rate", "5000.0");
     existingClientQuotas.put("<default>", defaultClientProps);
 
     // entry with empty props should be ignored (signifies a deleted config)
@@ -93,13 +93,13 @@ public class QuotaServiceTest {
         .thenReturn(JavaConverters.mapAsScalaMapConverter(existingClientQuotas).asScala());
 
     List<ConfiguredQuota> expected = new ArrayList<>();
-    expected.add(new ConfiguredQuota("user1", "client1", 100, null, null));
-    expected.add(new ConfiguredQuota("<default>", "<default>", 200, 500, 80));
-    expected.add(new ConfiguredQuota("user1", null, 3000, 2000, null));
-    expected.add(new ConfiguredQuota("user2", null, null, null, 40));
-    expected.add(new ConfiguredQuota("<default>", null, 7000, 6000, null));
-    expected.add(new ConfiguredQuota(null, "client1", 150, null, 200));
-    expected.add(new ConfiguredQuota(null, "<default>", 5000, null, null));
+    expected.add(new ConfiguredQuota("user1", "client1", 100., null, null));
+    expected.add(new ConfiguredQuota("<default>", "<default>", 200., 500., 80.));
+    expected.add(new ConfiguredQuota("user1", null, 3000., 2000., null));
+    expected.add(new ConfiguredQuota("user2", null, null, null, 40.));
+    expected.add(new ConfiguredQuota("<default>", null, 7000., 6000., null));
+    expected.add(new ConfiguredQuota(null, "client1", 150., null, 200.));
+    expected.add(new ConfiguredQuota(null, "<default>", 5000., null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     Collection<ConfiguredQuota> actual = svc.listExisting();
@@ -110,27 +110,27 @@ public class QuotaServiceTest {
   @Test
   public void testCreateQuotas() {
     List<ConfiguredQuota> toCreate = new ArrayList<>();
-    toCreate.add(new ConfiguredQuota("user1", "<default>", 100, null, null));
-    toCreate.add(new ConfiguredQuota("user2", null, null, null, 40));
-    toCreate.add(new ConfiguredQuota("<default>", null, 7000, 6000, null));
-    toCreate.add(new ConfiguredQuota(null, "client1", 150, null, 200));
-    toCreate.add(new ConfiguredQuota(null, "<default>", 5000, null, null));
+    toCreate.add(new ConfiguredQuota("user1", "<default>", 100., null, null));
+    toCreate.add(new ConfiguredQuota("user2", null, null, null, 40.));
+    toCreate.add(new ConfiguredQuota("<default>", null, 7000., 6000., null));
+    toCreate.add(new ConfiguredQuota(null, "client1", 150., null, 200.));
+    toCreate.add(new ConfiguredQuota(null, "<default>", 5000., null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     svc.create(toCreate);
 
     Properties user1DefaultClientProps = new Properties();
-    user1DefaultClientProps.put("producer_byte_rate", "100");
+    user1DefaultClientProps.put("producer_byte_rate", "100.0");
     Properties user2Props = new Properties();
-    user2Props.put("request_percentage", "40");
+    user2Props.put("request_percentage", "40.0");
     Properties defaultUserProps = new Properties();
-    defaultUserProps.put("producer_byte_rate", "7000");
-    defaultUserProps.put("consumer_byte_rate", "6000");
+    defaultUserProps.put("producer_byte_rate", "7000.0");
+    defaultUserProps.put("consumer_byte_rate", "6000.0");
     Properties client1Props = new Properties();
-    client1Props.put("producer_byte_rate", "150");
-    client1Props.put("request_percentage", "200");
+    client1Props.put("producer_byte_rate", "150.0");
+    client1Props.put("request_percentage", "200.0");
     Properties defaultClientProps = new Properties();
-    defaultClientProps.put("producer_byte_rate", "5000");
+    defaultClientProps.put("producer_byte_rate", "5000.0");
 
     verify(adminClient).changeConfigs(ConfigType.User(), "user1/clients/<default>", user1DefaultClientProps);
     verify(adminClient).changeConfigs(ConfigType.User(), "user2", user2Props);
@@ -143,11 +143,11 @@ public class QuotaServiceTest {
   @Test
   public void testDeleteQuotas() {
     List<ConfiguredQuota> toDelete = new ArrayList<>();
-    toDelete.add(new ConfiguredQuota("user1", "<default>", 100, null, null));
-    toDelete.add(new ConfiguredQuota("user2", null, null, null, 40));
-    toDelete.add(new ConfiguredQuota("<default>", null, 7000, 6000, null));
-    toDelete.add(new ConfiguredQuota(null, "client1", 150, null, 200));
-    toDelete.add(new ConfiguredQuota(null, "<default>", 5000, null, null));
+    toDelete.add(new ConfiguredQuota("user1", "<default>", 100., null, null));
+    toDelete.add(new ConfiguredQuota("user2", null, null, null, 40.));
+    toDelete.add(new ConfiguredQuota("<default>", null, 7000., 6000., null));
+    toDelete.add(new ConfiguredQuota(null, "client1", 150., null, 200.));
+    toDelete.add(new ConfiguredQuota(null, "<default>", 5000., null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     svc.delete(toDelete);

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaServiceTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaServiceTest.java
@@ -93,13 +93,13 @@ public class QuotaServiceTest {
         .thenReturn(JavaConverters.mapAsScalaMapConverter(existingClientQuotas).asScala());
 
     List<ConfiguredQuota> expected = new ArrayList<>();
-    expected.add(new ConfiguredQuota("user1", "client1", 100., null, null));
-    expected.add(new ConfiguredQuota("<default>", "<default>", 200., 500., 80.));
-    expected.add(new ConfiguredQuota("user1", null, 3000., 2000., null));
-    expected.add(new ConfiguredQuota("user2", null, null, null, 40.));
-    expected.add(new ConfiguredQuota("<default>", null, 7000., 6000., null));
-    expected.add(new ConfiguredQuota(null, "client1", 150., null, 200.));
-    expected.add(new ConfiguredQuota(null, "<default>", 5000., null, null));
+    expected.add(new ConfiguredQuota("user1", "client1", 100d, null, null));
+    expected.add(new ConfiguredQuota("<default>", "<default>", 200d, 500d, 80d));
+    expected.add(new ConfiguredQuota("user1", null, 3000d, 2000d, null));
+    expected.add(new ConfiguredQuota("user2", null, null, null, 40d));
+    expected.add(new ConfiguredQuota("<default>", null, 7000d, 6000d, null));
+    expected.add(new ConfiguredQuota(null, "client1", 150d, null, 200d));
+    expected.add(new ConfiguredQuota(null, "<default>", 5000d, null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     Collection<ConfiguredQuota> actual = svc.listExisting();
@@ -110,11 +110,11 @@ public class QuotaServiceTest {
   @Test
   public void testCreateQuotas() {
     List<ConfiguredQuota> toCreate = new ArrayList<>();
-    toCreate.add(new ConfiguredQuota("user1", "<default>", 100., null, null));
-    toCreate.add(new ConfiguredQuota("user2", null, null, null, 40.));
-    toCreate.add(new ConfiguredQuota("<default>", null, 7000., 6000., null));
-    toCreate.add(new ConfiguredQuota(null, "client1", 150., null, 200.));
-    toCreate.add(new ConfiguredQuota(null, "<default>", 5000., null, null));
+    toCreate.add(new ConfiguredQuota("user1", "<default>", 100d, null, null));
+    toCreate.add(new ConfiguredQuota("user2", null, null, null, 40d));
+    toCreate.add(new ConfiguredQuota("<default>", null, 7000d, 6000d, null));
+    toCreate.add(new ConfiguredQuota(null, "client1", 150d, null, 200d));
+    toCreate.add(new ConfiguredQuota(null, "<default>", 5000d, null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     svc.create(toCreate);
@@ -143,11 +143,11 @@ public class QuotaServiceTest {
   @Test
   public void testDeleteQuotas() {
     List<ConfiguredQuota> toDelete = new ArrayList<>();
-    toDelete.add(new ConfiguredQuota("user1", "<default>", 100., null, null));
-    toDelete.add(new ConfiguredQuota("user2", null, null, null, 40.));
-    toDelete.add(new ConfiguredQuota("<default>", null, 7000., 6000., null));
-    toDelete.add(new ConfiguredQuota(null, "client1", 150., null, 200.));
-    toDelete.add(new ConfiguredQuota(null, "<default>", 5000., null, null));
+    toDelete.add(new ConfiguredQuota("user1", "<default>", 100d, null, null));
+    toDelete.add(new ConfiguredQuota("user2", null, null, null, 40d));
+    toDelete.add(new ConfiguredQuota("<default>", null, 7000d, 6000d, null));
+    toDelete.add(new ConfiguredQuota(null, "client1", 150d, null, 200d));
+    toDelete.add(new ConfiguredQuota(null, "<default>", 5000d, null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     svc.delete(toDelete);


### PR DESCRIPTION
This is to be consistent with Kafka's settings. Some tests are explicitly using integers in Kafka config to test the backward compatibility.

Note that this change is backward compatible. However, this commit is NOT rollback-safe, as new quota values will be set with decimals such as "10.0" in ZooKeeper even if the quota is set as integers in the config file, and if we rollback to older version of enforcer, it will fail at these decimal numbers.