### PR TITLE
Implement Kafka Admin Client based Quota Service.

### DIFF
--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/AdminClientQuotaService.java
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/AdminClientQuotaService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. Tesla Motors, Inc. All rights reserved.
+ * Copyright (c) 2025. Tesla Motors, Inc. All rights reserved.
  */
 
 package com.tesla.data.quota.enforcer;

--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/AdminClientQuotaService.java
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/AdminClientQuotaService.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2021. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.quota.enforcer;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.common.quota.ClientQuotaAlteration;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.common.quota.ClientQuotaFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class AdminClientQuotaService {
+  protected final Logger LOG = LoggerFactory.getLogger(getClass());
+
+  private static final String PRODUCER_BYTE_RATE = "producer_byte_rate";
+  private static final String CONSUMER_BYTE_RATE = "consumer_byte_rate";
+  private static final String REQUEST_PERCENTAGE = "request_percentage";
+
+  private static final List<String> SUPPORTED_QUOTA_TYPES = List.of(PRODUCER_BYTE_RATE, CONSUMER_BYTE_RATE, REQUEST_PERCENTAGE);
+  private static final List<String> SUPPORTED_ENTITY_KEYS = List.of(ClientQuotaEntity.USER, ClientQuotaEntity.CLIENT_ID);
+
+  private static final Collection<ClientQuotaAlteration.Op> CLEAR_ALL = SUPPORTED_QUOTA_TYPES.stream().map(t ->
+      new ClientQuotaAlteration.Op(t, null)).collect(Collectors.toUnmodifiableList());
+
+  private final AdminClient adminClient;
+
+  public AdminClientQuotaService(AdminClient adminClient) {
+    this.adminClient = adminClient;
+  }
+
+  /**
+   * Build and return a collection of {@link ConfiguredQuota} that currently exist. Drops any returned quota entry
+   * that contains an empty configuration/property map -- these signify that the quota had been previously deleted.
+   */
+  public Collection<ConfiguredQuota> listExisting() {
+    try {
+      Map<ClientQuotaEntity, Map<String, Double>> clientQuotas = adminClient.describeClientQuotas(ClientQuotaFilter.all()).entities().get();
+
+      return clientQuotas.entrySet().stream().map(this::configuredQuota).filter(Objects::nonNull).collect(Collectors.toSet());
+    } catch (InterruptedException | ExecutionException e) {
+      // TODO: Improve exception handling
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void create(Collection<ConfiguredQuota> quotas) {
+    Collection<ClientQuotaAlteration> alters = quotas.stream().map(q -> {
+      // For unspecified quota types, ConfigureQuota returns null. We use such null value directly in
+      // ClientQuotaAlternation.Op to clear the quota types in the cluster.
+      Collection<ClientQuotaAlteration.Op> ops = List.of(
+          new ClientQuotaAlteration.Op(PRODUCER_BYTE_RATE, q.getProducerByteRate()),
+          new ClientQuotaAlteration.Op(CONSUMER_BYTE_RATE, q.getConsumerByteRate()),
+          new ClientQuotaAlteration.Op(REQUEST_PERCENTAGE, q.getRequestPercentage()));
+      return new ClientQuotaAlteration(getClientQuotaEntity(q), ops);
+    }).collect(Collectors.toList());
+
+    try {
+      adminClient.alterClientQuotas(alters).all().get();
+    } catch (InterruptedException | ExecutionException e) {
+      // TODO: Improve exception handling
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void delete(Collection<ConfiguredQuota> quotas) {
+    Collection<ClientQuotaAlteration> alters = quotas.stream().map(q ->
+        new ClientQuotaAlteration(getClientQuotaEntity(q), CLEAR_ALL)).collect(Collectors.toList());
+
+    try {
+      adminClient.alterClientQuotas(alters).all().get();
+    } catch (InterruptedException | ExecutionException e) {
+      // TODO: Improve exception handling
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * A helper function that converts a client quota entity entry to a {@link ConfiguredQuota} and returns null if the
+   * quota entry is deleted or unsupported.
+   */
+  private ConfiguredQuota configuredQuota(Map.Entry<ClientQuotaEntity, Map<String, Double>> quotaEntry) {
+    ClientQuotaEntity entity = quotaEntry.getKey();
+    if (entity.entries().keySet().stream().anyMatch(Predicate.not(SUPPORTED_ENTITY_KEYS::contains))) {
+      LOG.warn("Skipping unsupported quota entity {}.", entity);
+      return null;
+    }
+
+    Map<String, Double> quotas = quotaEntry.getValue();
+    List<String> unsupportedQuotaTypes = quotas.keySet().stream().filter(Predicate.not(SUPPORTED_QUOTA_TYPES::contains))
+        .collect(Collectors.toUnmodifiableList());
+    if (!unsupportedQuotaTypes.isEmpty()) {
+      LOG.warn("Ignoring unsupported quota types {} of entity {}.", unsupportedQuotaTypes, entity);
+    }
+    // Skips the entries that don't contain any supported quota types to skip previously deleted quota entries.
+    if (Collections.disjoint(quotas.keySet(), SUPPORTED_QUOTA_TYPES)) {
+      return null;
+    }
+
+    return new ConfiguredQuota(
+        getEntityName(entity, ClientQuotaEntity.USER),
+        getEntityName(entity, ClientQuotaEntity.CLIENT_ID),
+        quotas.get(PRODUCER_BYTE_RATE),
+        quotas.get(CONSUMER_BYTE_RATE),
+        quotas.get(REQUEST_PERCENTAGE));
+  }
+
+  /**
+   * A helper function to extract the entity name under a key from a {@link ClientQuotaEntity} while converting the
+   * null-value / default-value semantics to follow {@link ConfiguredQuota}:
+   * <ul>
+   *   <li>Explicit default entity is expressed as a constant string "&lt;default&gt;" instead of null;</li>
+   *   <li>Unspecified entity name is expressed as null instead of absence.</li>
+   * </ul>
+   */
+  private String getEntityName(ClientQuotaEntity entity, String key) {
+    if (!entity.entries().containsKey(key)) {
+      return null;
+    }
+    if (entity.entries().get(key) == null) {
+      return ConfiguredQuota.ENTITY_DEFAULT;
+    }
+    return entity.entries().get(key);
+  }
+
+
+  /**
+   * A helper function to set the entity name under a key in a {@link ClientQuotaEntity} entries while converting the
+   * null-value / default-value semantics from  {@link ConfiguredQuota}:
+   * <ul>
+   *   <li>Explicit default entity is expressed as null instead of the string "&lt;default&gt;";</li>
+   *   <li>Unspecified entity name is not set instead of set as null.</li>
+   * </ul>
+   */
+  private void putEntityName(Map<String, String> entity, String key, String name) {
+    if (name == null) {
+      return;
+    }
+    if (name.equals(ConfiguredQuota.ENTITY_DEFAULT)) {
+      entity.put(key, null);
+      return;
+    }
+    entity.put(key, name);
+  }
+
+  private ClientQuotaEntity getClientQuotaEntity(ConfiguredQuota quota) {
+    Map<String, String> entity = new HashMap<>();
+    putEntityName(entity, ClientQuotaEntity.USER, quota.getPrincipal());
+    putEntityName(entity, ClientQuotaEntity.CLIENT_ID, quota.getClient());
+    return new ClientQuotaEntity(entity);
+  }
+}

--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/BUILD
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/BUILD
@@ -10,6 +10,7 @@ java_library(
         "//3rdparty/jvm/org/apache/kafka:kafka_clients",
         "//3rdparty/jvm/org/apache/zookeeper",
         "//3rdparty/jvm/org/scala_lang:scala_library",
+        "//3rdparty/jvm/org/slf4j:slf4j_api",
         "//3rdparty/jvm_shaded/com/google/guava_shaded",
         "//kafka_enforcer_common/src/main/java/com/tesla/data/enforcer",
     ],

--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/ConfiguredQuota.java
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/ConfiguredQuota.java
@@ -10,9 +10,13 @@ import tesla.shade.com.google.common.base.Objects;
 import tesla.shade.com.google.common.base.Preconditions;
 
 /**
- * ConfiguredQuota represents a quota and its desired configuration.
+ * ConfiguredQuota represents a quota and its desired configuration. Unset quota types return null values. For entity
+ * names such as principal or client, null values indicate unspecified, while ENTITY_DEFAULT expresses default entities.
  */
 public class ConfiguredQuota {
+  // Represents the default for an entity type, such as client or principal.
+  public static final String ENTITY_DEFAULT = "<default>";
+
   private final String principal;
   private final String client;
   @JsonProperty("producer-byte-rate")

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/AdminClientQuotaServiceTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/AdminClientQuotaServiceTest.java
@@ -41,7 +41,7 @@ public class AdminClientQuotaServiceTest {
   private ArgumentCaptor<Collection<ClientQuotaAlteration>> captor;
 
   @Before
-  public void init(){
+  public void init() {
     MockitoAnnotations.openMocks(this);
   }
 
@@ -50,7 +50,7 @@ public class AdminClientQuotaServiceTest {
    * A helper function to allow us to initialize a {@link Map} with null values.
    * The static factory does not allow null values, but Kafka API is using null values for specific purposes.
    */
-  private static <K,V> Map<K, V> nullableMap(Collection<Map.Entry<K, V>> entries) {
+  private static <K, V> Map<K, V> nullableMap(Collection<Map.Entry<K, V>> entries) {
     Map<K, V> m = new HashMap<>();
     entries.forEach(e -> m.put(e.getKey(), e.getValue()));
     return m;
@@ -126,6 +126,7 @@ public class AdminClientQuotaServiceTest {
       Assert.assertEquals("check ops for " + e.entity().toString(), e.ops(), a.ops());
     }
   }
+
   @Test
   public void testCreateQuotas() {
     List<ConfiguredQuota> toCreate = List.of(

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/AdminClientQuotaServiceTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/AdminClientQuotaServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. Tesla Motors, Inc. All rights reserved.
+ * Copyright (c) 2025. Tesla Motors, Inc. All rights reserved.
  */
 
 package com.tesla.data.quota.enforcer;

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/AdminClientQuotaServiceTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/AdminClientQuotaServiceTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2021. Tesla Motors, Inc. All rights reserved.
+ */
+
+package com.tesla.data.quota.enforcer;
+
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterClientQuotasResult;
+import org.apache.kafka.clients.admin.DescribeClientQuotasResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.quota.ClientQuotaAlteration;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.common.quota.ClientQuotaFilter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AdminClientQuotaServiceTest {
+
+  @Mock
+  private AdminClient adminClient;
+
+  @Captor
+  private ArgumentCaptor<Collection<ClientQuotaAlteration>> captor;
+
+  @Before
+  public void init(){
+    MockitoAnnotations.openMocks(this);
+  }
+
+
+  /**
+   * A helper function to allow us to initialize a {@link Map} with null values.
+   * The static factory does not allow null values, but Kafka API is using null values for specific purposes.
+   */
+  private static <K,V> Map<K, V> nullableMap(Collection<Map.Entry<K, V>> entries) {
+    Map<K, V> m = new HashMap<>();
+    entries.forEach(e -> m.put(e.getKey(), e.getValue()));
+    return m;
+  }
+
+  @Test
+  public void testListExisting() {
+    Map<ClientQuotaEntity, Map<String, Double>> existingQuotas = Map.of(
+        // explicit user and explicit client
+        new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "user1", ClientQuotaEntity.CLIENT_ID, "client1")),
+        Map.of("producer_byte_rate", 100d),
+        // explicit user and unspecified client
+        new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "user1")),
+        Map.of("producer_byte_rate", 3000d, "consumer_byte_rate", 2000d),
+        // explicit client and unspecified user with unsupported quota props
+        new ClientQuotaEntity(Map.of(ClientQuotaEntity.CLIENT_ID, "client1")),
+        Map.of("producer_byte_rate", 150d, "request_percentage", 200d, "unsupported-quota", 1d),
+        // default user and default client as expressed by the Kafka API convention
+        new ClientQuotaEntity(nullableMap(List.of(
+            new AbstractMap.SimpleEntry<>(ClientQuotaEntity.USER, null),
+            new AbstractMap.SimpleEntry<>(ClientQuotaEntity.CLIENT_ID, null)
+        ))),
+        Map.of("producer_byte_rate", 200d, "consumer_byte_rate", 500d, "request_percentage", 80d),
+        // default user and unspecified client as expressed by the Kafka API convention
+        new ClientQuotaEntity(nullableMap(List.of(
+            new AbstractMap.SimpleEntry<>(ClientQuotaEntity.USER, null)
+        ))),
+        Map.of("producer_byte_rate", 7000d, "consumer_byte_rate", 6000d),
+        // default client and unspecified user as expressed by the Kafka API convention
+        new ClientQuotaEntity(nullableMap(List.of(
+            new AbstractMap.SimpleEntry<>(ClientQuotaEntity.CLIENT_ID, null)
+        ))),
+        Map.of("producer_byte_rate", 5000d),
+        // entry with empty props should be ignored (signifies a deleted config)
+        new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "deleted", ClientQuotaEntity.CLIENT_ID, "deleted")),
+        Map.of(),
+        // entry with only unsupported props should be ignored (signifies a deleted config)
+        new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "ignored")), Map.of("unsupported-quota", 1d),
+        // entry with unsupported entity types are ignored
+        new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "user1", "OCCUPATION", "pilot")),
+        Map.of("producer_byte_rate", 3000d, "consumer_byte_rate", 2000d)
+    );
+
+    Set<ConfiguredQuota> expected = Set.of(
+        new ConfiguredQuota("user1", "client1", 100d, null, null),
+        new ConfiguredQuota("user1", null, 3000d, 2000d, null),
+        new ConfiguredQuota(null, "client1", 150d, null, 200d),
+        new ConfiguredQuota("<default>", "<default>", 200d, 500d, 80d),
+        new ConfiguredQuota("<default>", null, 7000d, 6000d, null),
+        new ConfiguredQuota(null, "<default>", 5000d, null, null)
+    );
+
+    when(adminClient.describeClientQuotas(ClientQuotaFilter.all()))
+        .thenReturn(new DescribeClientQuotasResult(KafkaFuture.completedFuture(existingQuotas)));
+    AdminClientQuotaService svc = new AdminClientQuotaService(adminClient);
+    Set<ConfiguredQuota> actual = new HashSet<>(svc.listExisting());
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  // We have to manually asset because Kafka library does not override equals function of ClientQuotaAlteration.
+  private void assertClientQuotaAlterationCollectionEquals(
+      Collection<ClientQuotaAlteration> expected, Collection<ClientQuotaAlteration> actual) {
+    Assert.assertEquals("size diffs", expected.size(), actual.size());
+
+    Iterator<ClientQuotaAlteration> ei = expected.iterator();
+    Iterator<ClientQuotaAlteration> ai = actual.iterator();
+    while (ei.hasNext() && ai.hasNext()) {
+      ClientQuotaAlteration e = ei.next();
+      ClientQuotaAlteration a = ai.next();
+
+      Assert.assertEquals(e.entity(), a.entity());
+      Assert.assertEquals("check ops for " + e.entity().toString(), e.ops(), a.ops());
+    }
+  }
+  @Test
+  public void testCreateQuotas() {
+    List<ConfiguredQuota> toCreate = List.of(
+        new ConfiguredQuota("user1", "client1", 101d, null, null),
+        new ConfiguredQuota("user1", "<default>", 100d, null, null),
+        new ConfiguredQuota("user2", null, null, null, 40d),
+        new ConfiguredQuota("<default>", null, 7000d, 6000d, null),
+        new ConfiguredQuota(null, "client1", 150d, null, 200d),
+        new ConfiguredQuota(null, "<default>", 5000d, null, null)
+    );
+
+    Collection<ClientQuotaAlteration> expected = List.of(
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(Map.of(
+                ClientQuotaEntity.USER, "user1", ClientQuotaEntity.CLIENT_ID, "client1")),
+            List.of(
+                new ClientQuotaAlteration.Op("producer_byte_rate", 101d),
+                new ClientQuotaAlteration.Op("consumer_byte_rate", null),
+                new ClientQuotaAlteration.Op("request_percentage", null)
+            )
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(nullableMap(List.of(
+                new AbstractMap.SimpleEntry<>(ClientQuotaEntity.USER, "user1"),
+                new AbstractMap.SimpleEntry<>(ClientQuotaEntity.CLIENT_ID, null)
+            ))),
+            List.of(
+                new ClientQuotaAlteration.Op("producer_byte_rate", 100d),
+                new ClientQuotaAlteration.Op("consumer_byte_rate", null),
+                new ClientQuotaAlteration.Op("request_percentage", null)
+            )
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "user2")),
+            List.of(
+                new ClientQuotaAlteration.Op("producer_byte_rate", null),
+                new ClientQuotaAlteration.Op("consumer_byte_rate", null),
+                new ClientQuotaAlteration.Op("request_percentage", 40d)
+            )
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(nullableMap(List.of(new AbstractMap.SimpleEntry<>(ClientQuotaEntity.USER, null)))),
+            List.of(
+                new ClientQuotaAlteration.Op("producer_byte_rate", 7000d),
+                new ClientQuotaAlteration.Op("consumer_byte_rate", 6000d),
+                new ClientQuotaAlteration.Op("request_percentage", null)
+            )
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(Map.of(ClientQuotaEntity.CLIENT_ID, "client1")),
+            List.of(
+                new ClientQuotaAlteration.Op("producer_byte_rate", 150d),
+                new ClientQuotaAlteration.Op("consumer_byte_rate", null),
+                new ClientQuotaAlteration.Op("request_percentage", 200d)
+            )
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(nullableMap(List.of(
+                new AbstractMap.SimpleEntry<>(ClientQuotaEntity.CLIENT_ID, null)))),
+            List.of(
+                new ClientQuotaAlteration.Op("producer_byte_rate", 5000d),
+                new ClientQuotaAlteration.Op("consumer_byte_rate", null),
+                new ClientQuotaAlteration.Op("request_percentage", null)
+            )
+        )
+    );
+
+    when(adminClient.alterClientQuotas(anyCollection())).thenReturn(new AlterClientQuotasResult(
+        Map.of(new ClientQuotaEntity(Map.of("don't", "matter")), KafkaFuture.completedFuture(null))));
+    AdminClientQuotaService svc = new AdminClientQuotaService(adminClient);
+    svc.create(toCreate);
+    verify(adminClient).alterClientQuotas(captor.capture());
+    Collection<ClientQuotaAlteration> actual = captor.getValue();
+
+    assertClientQuotaAlterationCollectionEquals(expected, actual);
+  }
+
+  @Test
+  public void testDeleteQuotas() {
+    List<ConfiguredQuota> toDelete = List.of(
+        new ConfiguredQuota("user1", "client1", 101d, null, null),
+        new ConfiguredQuota("user1", "<default>", 100d, null, null),
+        new ConfiguredQuota("user2", null, null, null, 40d),
+        new ConfiguredQuota("<default>", null, 7000d, 6000d, null),
+        new ConfiguredQuota(null, "client1", 150d, null, 200d),
+        new ConfiguredQuota(null, "<default>", 5000d, null, null)
+    );
+
+    final Collection<ClientQuotaAlteration.Op> CLEAR_ALL = List.of(
+        new ClientQuotaAlteration.Op("producer_byte_rate", null),
+        new ClientQuotaAlteration.Op("consumer_byte_rate", null),
+        new ClientQuotaAlteration.Op("request_percentage", null)
+    );
+
+    Collection<ClientQuotaAlteration> expected = List.of(
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(Map.of(
+                ClientQuotaEntity.USER, "user1", ClientQuotaEntity.CLIENT_ID, "client1")),
+            CLEAR_ALL
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(nullableMap(List.of(
+                new AbstractMap.SimpleEntry<>(ClientQuotaEntity.USER, "user1"),
+                new AbstractMap.SimpleEntry<>(ClientQuotaEntity.CLIENT_ID, null)
+            ))),
+            CLEAR_ALL
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "user2")),
+            CLEAR_ALL
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(nullableMap(List.of(new AbstractMap.SimpleEntry<>(ClientQuotaEntity.USER, null)))),
+            CLEAR_ALL
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(Map.of(ClientQuotaEntity.CLIENT_ID, "client1")),
+            CLEAR_ALL
+        ),
+        new ClientQuotaAlteration(
+            new ClientQuotaEntity(nullableMap(List.of(
+                new AbstractMap.SimpleEntry<>(ClientQuotaEntity.CLIENT_ID, null)))),
+            CLEAR_ALL
+        )
+    );
+
+    when(adminClient.alterClientQuotas(anyCollection())).thenReturn(new AlterClientQuotasResult(
+        Map.of(new ClientQuotaEntity(Map.of("don't", "matter")), KafkaFuture.completedFuture(null))));
+    AdminClientQuotaService svc = new AdminClientQuotaService(adminClient);
+    svc.delete(toDelete);
+    verify(adminClient).alterClientQuotas(captor.capture());
+    Collection<ClientQuotaAlteration> actual = captor.getValue();
+
+    assertClientQuotaAlterationCollectionEquals(expected, actual);
+  }
+}

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/BUILD
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/BUILD
@@ -33,3 +33,17 @@ java_test(
         "//kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer",
     ],
 )
+
+java_test(
+    name = "AdminClientQuotaServiceTest",
+    srcs = [
+        "AdminClientQuotaServiceTest.java",
+    ],
+    deps = [
+        "//3rdparty/jvm/org/apache/kafka",
+        "//3rdparty/jvm/org/apache/kafka:kafka_clients",
+        "//3rdparty/jvm/org/mockito:mockito_core",
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        "//kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer",
+    ],
+)


### PR DESCRIPTION
We are implementing a Quota Service that does not rely on ZooKeeper following Kafka's documentation that can be found at https://kafka.apache.org/28/javadoc/org/apache/kafka/clients/admin/Admin.html. Unit tests are also included for this newly created Quota Service.

Our intention is to update and replace the current ZooKeeper based Quota Service to resolve #55. For now, we are only adding the new implementation without using it in the enforcer to avoid breaking existing use cases, while we are still adding new features.