### PR TITLE
Quota enforcer truncates producer / consumer byte rates to integers as required by Kafka.

### DIFF
--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/AdminClientQuotaService.java
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/AdminClientQuotaService.java
@@ -60,8 +60,8 @@ public class AdminClientQuotaService {
       // For unspecified quota types, ConfigureQuota returns null. We use such null value directly in
       // ClientQuotaAlternation.Op to clear the quota types in the cluster.
       Collection<ClientQuotaAlteration.Op> ops = List.of(
-          new ClientQuotaAlteration.Op(PRODUCER_BYTE_RATE, q.getProducerByteRate()),
-          new ClientQuotaAlteration.Op(CONSUMER_BYTE_RATE, q.getConsumerByteRate()),
+          new ClientQuotaAlteration.Op(PRODUCER_BYTE_RATE, q.getProducerByteRate() != null ? q.getProducerByteRate().doubleValue() : null),
+          new ClientQuotaAlteration.Op(CONSUMER_BYTE_RATE, q.getConsumerByteRate() != null ? q.getConsumerByteRate().doubleValue() : null),
           new ClientQuotaAlteration.Op(REQUEST_PERCENTAGE, q.getRequestPercentage()));
       return new ClientQuotaAlteration(getClientQuotaEntity(q), ops);
     }).collect(Collectors.toList());
@@ -111,8 +111,8 @@ public class AdminClientQuotaService {
     return new ConfiguredQuota(
         getEntityName(entity, ClientQuotaEntity.USER),
         getEntityName(entity, ClientQuotaEntity.CLIENT_ID),
-        quotas.get(PRODUCER_BYTE_RATE),
-        quotas.get(CONSUMER_BYTE_RATE),
+        quotas.get(PRODUCER_BYTE_RATE) != null ? quotas.get(PRODUCER_BYTE_RATE).intValue() : null,
+        quotas.get(CONSUMER_BYTE_RATE) != null ? quotas.get(CONSUMER_BYTE_RATE).intValue() : null,
         quotas.get(REQUEST_PERCENTAGE));
   }
 

--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/ConfiguredQuota.java
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/ConfiguredQuota.java
@@ -20,14 +20,14 @@ public class ConfiguredQuota {
   private final String principal;
   private final String client;
   @JsonProperty("producer-byte-rate")
-  private final Double producerByteRate;
+  private final Integer producerByteRate;
   @JsonProperty("consumer-byte-rate")
-  private final Double consumerByteRate;
+  private final Integer consumerByteRate;
   @JsonProperty("request-percentage")
   private final Double requestPercentage;
 
-  public ConfiguredQuota(String principal, String client, Double producerByteRate,
-                         Double consumerByteRate, Double requestPercentage) {
+  public ConfiguredQuota(String principal, String client, Integer producerByteRate,
+                         Integer consumerByteRate, Double requestPercentage) {
     Preconditions.checkArgument(principal != null || client != null, "Invalid quota configuration detected. " +
         "At least one of 'principal' or 'client' must be provided.");
     this.principal = principal;
@@ -45,11 +45,11 @@ public class ConfiguredQuota {
     return client;
   }
 
-  public Double getProducerByteRate() {
+  public Integer getProducerByteRate() {
     return producerByteRate;
   }
 
-  public Double getConsumerByteRate() {
+  public Integer getConsumerByteRate() {
     return consumerByteRate;
   }
 

--- a/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/QuotaService.java
+++ b/kafka_quota_enforcer/src/main/java/com/tesla/data/quota/enforcer/QuotaService.java
@@ -6,6 +6,7 @@ package com.tesla.data.quota.enforcer;
 
 import kafka.server.ConfigType;
 import kafka.zk.AdminZkClient;
+import scala.collection.JavaConverters;
 
 import java.util.Collection;
 import java.util.Map;
@@ -14,8 +15,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import scala.collection.JavaConverters;
 
 public class QuotaService {
   private final AdminZkClient adminClient;
@@ -88,8 +87,8 @@ public class QuotaService {
 
   private ConfiguredQuota configuredQuota(Map.Entry<String, Properties> quotaEntry, EntityType entityType) {
     Properties quota = quotaEntry.getValue();
-    Double producerByteRate = getQuotaValue(quota, PRODUCER_BYTE_RATE);
-    Double consumerByteRate = getQuotaValue(quota, CONSUMER_BYTE_RATE);
+    Integer producerByteRate = getIntegerQuotaValue(quota, PRODUCER_BYTE_RATE);
+    Integer consumerByteRate = getIntegerQuotaValue(quota, CONSUMER_BYTE_RATE);
     Double requestPercentage = getQuotaValue(quota, REQUEST_PERCENTAGE);
 
     switch (entityType) {
@@ -113,10 +112,10 @@ public class QuotaService {
   private Properties quotaProperties(ConfiguredQuota quota) {
     Properties props = new Properties();
     if (quota.getProducerByteRate() != null) {
-      props.put(PRODUCER_BYTE_RATE, String.valueOf(quota.getProducerByteRate()));
+      props.put(PRODUCER_BYTE_RATE, String.valueOf(quota.getProducerByteRate().doubleValue()));
     }
     if (quota.getConsumerByteRate() != null) {
-      props.put(CONSUMER_BYTE_RATE, String.valueOf(quota.getConsumerByteRate()));
+      props.put(CONSUMER_BYTE_RATE, String.valueOf(quota.getConsumerByteRate().doubleValue()));
     }
     if (quota.getRequestPercentage() != null) {
       props.put(REQUEST_PERCENTAGE, String.valueOf(quota.getRequestPercentage()));
@@ -146,5 +145,9 @@ public class QuotaService {
    */
   private Double getQuotaValue(Properties quota, String quotaType) {
     return quota.get(quotaType) != null ? Double.valueOf(quota.getProperty(quotaType)) : null;
+  }
+
+  private Integer getIntegerQuotaValue(Properties quota, String quotaType) {
+    return quota.get(quotaType) != null ? Double.valueOf(quota.getProperty(quotaType)).intValue() : null;
   }
 }

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/AdminClientQuotaServiceTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/AdminClientQuotaServiceTest.java
@@ -91,16 +91,20 @@ public class AdminClientQuotaServiceTest {
         new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "ignored")), Map.of("unsupported-quota", 1d),
         // entry with unsupported entity types are ignored
         new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "user1", "OCCUPATION", "pilot")),
-        Map.of("producer_byte_rate", 3000d, "consumer_byte_rate", 2000d)
+        Map.of("producer_byte_rate", 3000d, "consumer_byte_rate", 2000d),
+        // fractional byte rates are truncated to integers
+        new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, "fractional")),
+        Map.of("producer_byte_rate", 3000.1, "consumer_byte_rate", 2000.2, "request_percentage", 80.1)
     );
 
     Set<ConfiguredQuota> expected = Set.of(
-        new ConfiguredQuota("user1", "client1", 100d, null, null),
-        new ConfiguredQuota("user1", null, 3000d, 2000d, null),
-        new ConfiguredQuota(null, "client1", 150d, null, 200d),
-        new ConfiguredQuota("<default>", "<default>", 200d, 500d, 80d),
-        new ConfiguredQuota("<default>", null, 7000d, 6000d, null),
-        new ConfiguredQuota(null, "<default>", 5000d, null, null)
+        new ConfiguredQuota("user1", "client1", 100, null, null),
+        new ConfiguredQuota("user1", null, 3000, 2000, null),
+        new ConfiguredQuota(null, "client1", 150, null, 200d),
+        new ConfiguredQuota("<default>", "<default>", 200, 500, 80d),
+        new ConfiguredQuota("<default>", null, 7000, 6000, null),
+        new ConfiguredQuota(null, "<default>", 5000, null, null),
+        new ConfiguredQuota("fractional", null, 3000, 2000, 80.1)
     );
 
     when(adminClient.describeClientQuotas(ClientQuotaFilter.all()))
@@ -130,12 +134,12 @@ public class AdminClientQuotaServiceTest {
   @Test
   public void testCreateQuotas() {
     List<ConfiguredQuota> toCreate = List.of(
-        new ConfiguredQuota("user1", "client1", 101d, null, null),
-        new ConfiguredQuota("user1", "<default>", 100d, null, null),
+        new ConfiguredQuota("user1", "client1", 101, null, null),
+        new ConfiguredQuota("user1", "<default>", 100, null, null),
         new ConfiguredQuota("user2", null, null, null, 40d),
-        new ConfiguredQuota("<default>", null, 7000d, 6000d, null),
-        new ConfiguredQuota(null, "client1", 150d, null, 200d),
-        new ConfiguredQuota(null, "<default>", 5000d, null, null)
+        new ConfiguredQuota("<default>", null, 7000, 6000, null),
+        new ConfiguredQuota(null, "client1", 150, null, 200d),
+        new ConfiguredQuota(null, "<default>", 5000, null, null)
     );
 
     Collection<ClientQuotaAlteration> expected = List.of(
@@ -207,12 +211,12 @@ public class AdminClientQuotaServiceTest {
   @Test
   public void testDeleteQuotas() {
     List<ConfiguredQuota> toDelete = List.of(
-        new ConfiguredQuota("user1", "client1", 101d, null, null),
-        new ConfiguredQuota("user1", "<default>", 100d, null, null),
+        new ConfiguredQuota("user1", "client1", 101, null, null),
+        new ConfiguredQuota("user1", "<default>", 100, null, null),
         new ConfiguredQuota("user2", null, null, null, 40d),
-        new ConfiguredQuota("<default>", null, 7000d, 6000d, null),
-        new ConfiguredQuota(null, "client1", 150d, null, 200d),
-        new ConfiguredQuota(null, "<default>", 5000d, null, null)
+        new ConfiguredQuota("<default>", null, 7000, 6000, null),
+        new ConfiguredQuota(null, "client1", 150, null, 200d),
+        new ConfiguredQuota(null, "<default>", 5000, null, null)
     );
 
     final Collection<ClientQuotaAlteration.Op> CLEAR_ALL = List.of(

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/ConfiguredQuotaTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/ConfiguredQuotaTest.java
@@ -20,18 +20,18 @@ public class ConfiguredQuotaTest {
   public void testBadConfiguration() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid quota configuration detected. At least one of 'principal' or 'client' must be provided.");
-    new ConfiguredQuota(null, null, 5000d, 4000d, 50d);
+    new ConfiguredQuota(null, null, 5000, 4000, 50d);
   }
 
   @Test
   public void testConfiguredQuotaEquals() {
-    ConfiguredQuota quota = new ConfiguredQuota("user1", "clientA", 2000d, 1000d, 50d);
-    Assert.assertEquals(quota, new ConfiguredQuota("user1", "clientA", 2000d, 1000d, 50d));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("badUser", "clientA", 2000d, 1000d, 50d));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "badClient", 2000d, 1000d, 50d));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 9999d, 1000d, 50d));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000d, 9999d, 50d));
-    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000d, 1000d, 99d));
+    ConfiguredQuota quota = new ConfiguredQuota("user1", "clientA", 2000, 1000, 50d);
+    Assert.assertEquals(quota, new ConfiguredQuota("user1", "clientA", 2000, 1000, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("badUser", "clientA", 2000, 1000, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "badClient", 2000, 1000, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 9999, 1000, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000, 9999, 50d));
+    Assert.assertNotEquals(quota, new ConfiguredQuota("user1", "clientA", 2000, 1000, 99d));
   }
 
   @Test
@@ -44,7 +44,7 @@ public class ConfiguredQuotaTest {
         "    - principal: user1",
         "      client: float-client",
         "      producer-byte-rate: 2000.0",
-        "      consumer-byte-rate: 1000.0",
+        "      consumer-byte-rate: 1000.1",
         "      request-percentage: 52.7",
         "    - principal: backward-compatible",
         "      client: all-integers",
@@ -56,7 +56,7 @@ public class ConfiguredQuotaTest {
     List<ConfiguredQuota> quotas =
         new BaseCommand<ConfiguredQuota>(config).configuredEntities(ConfiguredQuota.class, "quota", "quotaFile");
     Assert.assertEquals(quotas, List.of(
-        new ConfiguredQuota("user1", "float-client", 2000d, 1000d, 52.7),
-        new ConfiguredQuota("backward-compatible", "all-integers", 2000d, 1000d, 50d)));
+        new ConfiguredQuota("user1", "float-client", 2000, 1000, 52.7),
+        new ConfiguredQuota("backward-compatible", "all-integers", 2000, 1000, 50d)));
   }
 }

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaEnforcerTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaEnforcerTest.java
@@ -19,8 +19,8 @@ public class QuotaEnforcerTest {
 
   private QuotaService quotaService;
   private static final List<ConfiguredQuota> quotas = Arrays.asList(
-      new ConfiguredQuota("user1", "clientA", 5000d, 4000d, 100d),
-      new ConfiguredQuota("<default>", null, 6000d, 3000d, null)
+      new ConfiguredQuota("user1", "clientA", 5000, 4000, 100d),
+      new ConfiguredQuota("<default>", null, 6000, 3000, null)
   );
 
   @Before

--- a/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaServiceTest.java
+++ b/kafka_quota_enforcer/src/test/java/com/tesla/data/quota/enforcer/QuotaServiceTest.java
@@ -93,13 +93,13 @@ public class QuotaServiceTest {
         .thenReturn(JavaConverters.mapAsScalaMapConverter(existingClientQuotas).asScala());
 
     List<ConfiguredQuota> expected = new ArrayList<>();
-    expected.add(new ConfiguredQuota("user1", "client1", 100d, null, null));
-    expected.add(new ConfiguredQuota("<default>", "<default>", 200d, 500d, 80d));
-    expected.add(new ConfiguredQuota("user1", null, 3000d, 2000d, null));
+    expected.add(new ConfiguredQuota("user1", "client1", 100, null, null));
+    expected.add(new ConfiguredQuota("<default>", "<default>", 200, 500, 80d));
+    expected.add(new ConfiguredQuota("user1", null, 3000, 2000, null));
     expected.add(new ConfiguredQuota("user2", null, null, null, 40d));
-    expected.add(new ConfiguredQuota("<default>", null, 7000d, 6000d, null));
-    expected.add(new ConfiguredQuota(null, "client1", 150d, null, 200d));
-    expected.add(new ConfiguredQuota(null, "<default>", 5000d, null, null));
+    expected.add(new ConfiguredQuota("<default>", null, 7000, 6000, null));
+    expected.add(new ConfiguredQuota(null, "client1", 150, null, 200d));
+    expected.add(new ConfiguredQuota(null, "<default>", 5000, null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     Collection<ConfiguredQuota> actual = svc.listExisting();
@@ -110,11 +110,11 @@ public class QuotaServiceTest {
   @Test
   public void testCreateQuotas() {
     List<ConfiguredQuota> toCreate = new ArrayList<>();
-    toCreate.add(new ConfiguredQuota("user1", "<default>", 100d, null, null));
+    toCreate.add(new ConfiguredQuota("user1", "<default>", 100, null, null));
     toCreate.add(new ConfiguredQuota("user2", null, null, null, 40d));
-    toCreate.add(new ConfiguredQuota("<default>", null, 7000d, 6000d, null));
-    toCreate.add(new ConfiguredQuota(null, "client1", 150d, null, 200d));
-    toCreate.add(new ConfiguredQuota(null, "<default>", 5000d, null, null));
+    toCreate.add(new ConfiguredQuota("<default>", null, 7000, 6000, null));
+    toCreate.add(new ConfiguredQuota(null, "client1", 150, null, 200d));
+    toCreate.add(new ConfiguredQuota(null, "<default>", 5000, null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     svc.create(toCreate);
@@ -143,11 +143,11 @@ public class QuotaServiceTest {
   @Test
   public void testDeleteQuotas() {
     List<ConfiguredQuota> toDelete = new ArrayList<>();
-    toDelete.add(new ConfiguredQuota("user1", "<default>", 100d, null, null));
+    toDelete.add(new ConfiguredQuota("user1", "<default>", 100, null, null));
     toDelete.add(new ConfiguredQuota("user2", null, null, null, 40d));
-    toDelete.add(new ConfiguredQuota("<default>", null, 7000d, 6000d, null));
-    toDelete.add(new ConfiguredQuota(null, "client1", 150d, null, 200d));
-    toDelete.add(new ConfiguredQuota(null, "<default>", 5000d, null, null));
+    toDelete.add(new ConfiguredQuota("<default>", null, 7000, 6000, null));
+    toDelete.add(new ConfiguredQuota(null, "client1", 150, null, 200d));
+    toDelete.add(new ConfiguredQuota(null, "<default>", 5000, null, null));
 
     QuotaService svc = new QuotaService(adminClient);
     svc.delete(toDelete);


### PR DESCRIPTION
Even though Kafka API takes producer / consumer byte rates as double type as seen via #75 , it validates and requires them to be non fractional. This PR adds an implicit conversion to drop any fractional parts of these two types of quotas, no matter if it appears on the Kafka cluster settings or in the YAML config of the quota enforcer.

I'm not sure if this is ideal or not. Alternatively, we could just do nothing and let quota enforcer to fail so we know bad configs are rejected by Kafka. I'm leaving this PR for reviewers decisions.