### PR TITLE
Batch topic creations in Topic Enforcer.

### DIFF
--- a/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/TopicServiceImpl.java
+++ b/kafka_topic_enforcer/src/main/java/com/tesla/data/topic/enforcer/TopicServiceImpl.java
@@ -30,7 +30,8 @@ import java.util.concurrent.ExecutionException;
 public class TopicServiceImpl implements TopicService {
 
   private static final ListTopicsOptions EXCLUDE_INTERNAL = new ListTopicsOptions().listInternal(false);
-  private static final int MAX_PARTITIONS_PER_CREATE_BATCH = 10_000;
+  // The upper limit of total partitions of each create request. We are leaving a buffer from Kafka's 10k limit.
+  private static final int MAX_PARTITIONS_PER_CREATE_BATCH = 8_000;
 
   private final AdminClient adminClient;
   private final boolean dryRun;

--- a/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/TopicServiceImplTest.java
+++ b/kafka_topic_enforcer/src/test/java/com/tesla/data/topic/enforcer/TopicServiceImplTest.java
@@ -157,9 +157,9 @@ public class TopicServiceImplTest {
         any(CreateTopicsOptions.class))).thenReturn(createTopicsResult);
 
     service.create(List.of(
-        new ConfiguredTopic("g1t1", 9_000, (short) 2, Collections.emptyMap()),
+        new ConfiguredTopic("g1t1", 7_000, (short) 2, Collections.emptyMap()),
         new ConfiguredTopic("g1t2", 1_000, (short) 2, Collections.emptyMap()),
-        new ConfiguredTopic("g2", 9_000, (short) 2, Collections.emptyMap()),
+        new ConfiguredTopic("g2", 7_000, (short) 2, Collections.emptyMap()),
         new ConfiguredTopic("g3", 2_000, (short) 2, Collections.emptyMap()),
         new ConfiguredTopic("g4", 10_000, (short) 2, Collections.emptyMap())));
 


### PR DESCRIPTION
There is a hard-coded limit now in Kafka of 10k partitions per batch request.

https://github.com/apache/kafka/blob/618c87bb02e7b32347634f04db66018504b686af/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java#L1220

As a result, we will get the following error, specially for creating topics on large clusters: "Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.PolicyViolationException: Excessively large number of partitions per request."

This PR splits the new topics into batches based on the total partition numbers to fix this issue.