### PR TITLE
Allow overriding the Burrow cluster name

### DIFF
--- a/kafka_consumer_freshness_tracker/README.md
+++ b/kafka_consumer_freshness_tracker/README.md
@@ -85,6 +85,9 @@ clusters:
 The Kafka configs are passed directly to the consumer, so you can add any standard
 [Kafka consumers configs](https://kafka.apache.org/documentation/#newconsumerconfigs) as needed.
 
+`clusters[].name` is the Burrow cluster (`/v3/kafka/{name}`). Optional `metricsClusterLabel` overrides the Prometheus
+`cluster` label. If omitted, metrics use `name`.
+
 ### Additional Options
 
  * `port`
@@ -108,6 +111,16 @@ The Kafka configs are passed directly to the consumer, so you can add any standa
     * **Default: 15**
       * For smaller clusters or multiple clusters, you will want to adjust this to manage memory allocation (each
       consumer takes a non-trivial chunk of memory, which can add up when monitoring multiple clusters).
+ * `metricsClusterLabel`
+    * Prometheus `cluster` label for this cluster. Use when the Burrow API name should not appear in metrics.
+    * **Default: `name`**
+    ```yaml
+    clusters:
+      - name: remote-burrow
+        metricsClusterLabel: local-cluster
+        kafka:
+          bootstrap.servers: "kafka.example.com:9092"
+    ```
 
 ## Design
 

--- a/kafka_consumer_freshness_tracker/README.md
+++ b/kafka_consumer_freshness_tracker/README.md
@@ -85,8 +85,8 @@ clusters:
 The Kafka configs are passed directly to the consumer, so you can add any standard
 [Kafka consumers configs](https://kafka.apache.org/documentation/#newconsumerconfigs) as needed.
 
-`clusters[].name` is the Burrow cluster (`/v3/kafka/{name}`). Optional `metricsClusterLabel` overrides the Prometheus
-`cluster` label. If omitted, metrics use `name`.
+`clusters[].name` is the Prometheus `cluster` label. Optional `burrowClusterName` is the Burrow API cluster
+(`/v3/kafka/{name}`) when it differs. If omitted, Burrow uses `name`.
 
 ### Additional Options
 
@@ -111,13 +111,13 @@ The Kafka configs are passed directly to the consumer, so you can add any standa
     * **Default: 15**
       * For smaller clusters or multiple clusters, you will want to adjust this to manage memory allocation (each
       consumer takes a non-trivial chunk of memory, which can add up when monitoring multiple clusters).
- * `metricsClusterLabel`
-    * Prometheus `cluster` label for this cluster. Use when the Burrow API name should not appear in metrics.
+ * `burrowClusterName`
+    * Burrow API cluster (`/v3/kafka/{name}`). Use when it differs from the Prometheus `cluster` label.
     * **Default: `name`**
     ```yaml
     clusters:
-      - name: remote-burrow
-        metricsClusterLabel: local-cluster
+      - name: local-cluster
+        burrowClusterName: remote-burrow
         kafka:
           bootstrap.servers: "kafka.example.com:9092"
     ```

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -152,12 +152,17 @@ public class ConsumerFreshness {
               }
               return new AbstractMap.SimpleEntry<>((String) clusterConf.get("name"), queue);
             }).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+    loadMetricsClusterLabels(conf);
+
+    this.executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(workerThreadCount));
+  }
+
+  @VisibleForTesting
+  void loadMetricsClusterLabels(Map<String, Object> conf) {
     this.metricsClusterByBurrowName = ((List<Map<String, Object>>) conf.get("clusters")).stream()
         .collect(Collectors.toMap(
             clusterConf -> (String) clusterConf.get("name"),
             this::metricsCluster));
-
-    this.executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(workerThreadCount));
   }
 
   /**
@@ -189,7 +194,7 @@ public class ConsumerFreshness {
     try {
       bootstrapServersFromBurrow = new HashSet<>(this.burrow.getClusterBootstrapServers(clusterName));
     } catch (IOException e) {
-      this.metrics.burrowClusterDetailReadFailed.labels(clusterName).inc();
+      this.metrics.burrowClusterDetailReadFailed.labels(metricsCluster(clusterConf)).inc();
       return Optional.of("failed to read cluster detail from Burrow: " + e.getMessage());
     }
 
@@ -226,16 +231,9 @@ public class ConsumerFreshness {
 
   void setupForTesting(Burrow burrow, Map<String, ArrayBlockingQueue<KafkaConsumer>> workers,
       ListeningExecutorService executor) {
-    setupForTesting(burrow, workers, executor, Collections.emptyMap());
-  }
-
-  void setupForTesting(Burrow burrow, Map<String, ArrayBlockingQueue<KafkaConsumer>> workers,
-      ListeningExecutorService executor, Map<String, String> metricsClusterByBurrowName) {
     this.burrow = burrow;
     this.availableWorkers = workers;
     this.executor = executor;
-    this.metricsClusterByBurrowName = metricsClusterByBurrowName == null
-        ? Collections.emptyMap() : metricsClusterByBurrowName;
   }
 
   @VisibleForTesting

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -176,10 +176,6 @@ public class ConsumerFreshness {
     return (String) clusterConf.get("name");
   }
 
-  private String metricsCluster(Map<String, Object> clusterConf) {
-    return (String) clusterConf.get("name");
-  }
-
   private String metricsCluster(String burrowCluster) {
     return metricsClusterByBurrowName.getOrDefault(burrowCluster, burrowCluster);
   }
@@ -198,7 +194,7 @@ public class ConsumerFreshness {
     try {
       bootstrapServersFromBurrow = new HashSet<>(this.burrow.getClusterBootstrapServers(burrowName));
     } catch (IOException e) {
-      this.metrics.burrowClusterDetailReadFailed.labels(metricsCluster(clusterConf)).inc();
+      this.metrics.burrowClusterDetailReadFailed.labels((String) clusterConf.get("name")).inc();
       return Optional.of("failed to read cluster detail from Burrow: " + e.getMessage());
     }
 

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -69,6 +69,7 @@ public class ConsumerFreshness {
   // exposed for testing
   Burrow burrow;
   private Map<String, ArrayBlockingQueue<KafkaConsumer>> availableWorkers;
+  private Map<String, String> metricsClusterByBurrowName = Collections.emptyMap();
   private ListeningExecutorService executor;
 
   public static void main(String[] args) throws IOException, InterruptedException {
@@ -151,8 +152,27 @@ public class ConsumerFreshness {
               }
               return new AbstractMap.SimpleEntry<>((String) clusterConf.get("name"), queue);
             }).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+    this.metricsClusterByBurrowName = ((List<Map<String, Object>>) conf.get("clusters")).stream()
+        .collect(Collectors.toMap(
+            clusterConf -> (String) clusterConf.get("name"),
+            this::metricsCluster));
 
     this.executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(workerThreadCount));
+  }
+
+  /**
+   * Prometheus {@code cluster} label. Defaults to the Burrow cluster {@code name}.
+   */
+  private String metricsCluster(Map<String, Object> clusterConf) {
+    Object override = clusterConf.get("metricsClusterLabel");
+    if (override instanceof String && !((String) override).isEmpty()) {
+      return (String) override;
+    }
+    return (String) clusterConf.get("name");
+  }
+
+  private String metricsCluster(String burrowCluster) {
+    return metricsClusterByBurrowName.getOrDefault(burrowCluster, burrowCluster);
   }
 
   /**
@@ -206,9 +226,16 @@ public class ConsumerFreshness {
 
   void setupForTesting(Burrow burrow, Map<String, ArrayBlockingQueue<KafkaConsumer>> workers,
       ListeningExecutorService executor) {
+    setupForTesting(burrow, workers, executor, Collections.emptyMap());
+  }
+
+  void setupForTesting(Burrow burrow, Map<String, ArrayBlockingQueue<KafkaConsumer>> workers,
+      ListeningExecutorService executor, Map<String, String> metricsClusterByBurrowName) {
     this.burrow = burrow;
     this.availableWorkers = workers;
     this.executor = executor;
+    this.metricsClusterByBurrowName = metricsClusterByBurrowName == null
+        ? Collections.emptyMap() : metricsClusterByBurrowName;
   }
 
   @VisibleForTesting
@@ -231,7 +258,8 @@ public class ConsumerFreshness {
             }
             return workers != null;
           })
-          .peek(clusterClient -> metrics.lastClusterRunAttempt.labels(clusterClient.getCluster()).setToCurrentTime())
+          .peek(clusterClient -> metrics.lastClusterRunAttempt.labels(metricsCluster(clusterClient.getCluster()))
+              .setToCurrentTime())
           .map(this::measureCluster)
           .forEach(future -> {
             try {
@@ -262,7 +290,7 @@ public class ConsumerFreshness {
       Collections.sort(consumerGroups);
     } catch (IOException e) {
       LOG.error("Failed to read groups from burrow for cluster {}", client.getCluster(), e);
-      metrics.burrowClustersConsumersReadFailed.labels(client.getCluster()).inc();
+      metrics.burrowClustersConsumersReadFailed.labels(metricsCluster(client.getCluster())).inc();
       return Futures.immediateFailedFuture(e);
     }
 
@@ -270,7 +298,7 @@ public class ConsumerFreshness {
     try {
       ArrayBlockingQueue<KafkaConsumer> workers = this.availableWorkers.get(cluster);
       for (String consumerGroup : consumerGroups) {
-        completedConsumers.add(measureConsumer(client, workers, consumerGroup));
+        completedConsumers.add(measureConsumer(client, workers, consumerGroup, metricsCluster(cluster)));
       }
     } catch (InterruptedException e) {
       LOG.error("Interrupted while measuring consumers for {}", client.getCluster(), e);
@@ -308,7 +336,7 @@ public class ConsumerFreshness {
       if (successes > 0) {
         LOG.info("Got freshness for at least one partition for one consumer partition for {} marking the cluster " +
             "successful", cluster);
-        return cluster;
+        return metricsCluster(cluster);
       }
 
       throw new RuntimeException("No single partition for any topic for any consumer for cluster {}" + cluster +
@@ -333,7 +361,8 @@ public class ConsumerFreshness {
    */
   private ListenableFuture<List<PartitionResult>> measureConsumer(Burrow.ClusterClient burrow,
                                                          ArrayBlockingQueue<KafkaConsumer> workers,
-                                                         String consumerGroup) throws InterruptedException {
+                                                         String consumerGroup,
+                                                         String metricsCluster) throws InterruptedException {
     Map<String, Object> status;
     try {
       status = burrow.getConsumerGroupStatus(consumerGroup);
@@ -347,11 +376,11 @@ public class ConsumerFreshness {
       } else {
         LOG.error("Failed to read Burrow status for consumer {}. Skipping", consumerGroup, e);
       }
-      metrics.error.labels(burrow.getCluster(), consumerGroup).inc();
+      metrics.error.labels(metricsCluster, consumerGroup).inc();
       return Futures.immediateFuture(Collections.emptyList());
     } catch (IOException | IllegalStateException e) {
       LOG.error("Failed to read Burrow status for consumer {}. Skipping", consumerGroup, e);
-      metrics.error.labels(burrow.getCluster(), consumerGroup).inc();
+      metrics.error.labels(metricsCluster, consumerGroup).inc();
       return Futures.immediateFuture(Collections.emptyList());
     }
 
@@ -372,7 +401,7 @@ public class ConsumerFreshness {
       long offset = Long.parseLong(end.get("offset").toString());
       boolean upToDate = Long.parseLong(state.get("current_lag").toString()) == 0;
       FreshnessTracker.ConsumerOffset consumerState =
-          new FreshnessTracker.ConsumerOffset(burrow.getCluster(), consumerGroup, topic, partition, offset,
+          new FreshnessTracker.ConsumerOffset(metricsCluster, consumerGroup, topic, partition, offset,
               upToDate);
 
       // wait for a consumer to become available
@@ -403,7 +432,7 @@ public class ConsumerFreshness {
 
         @Override
         public void onFailure(Throwable throwable) {
-          metrics.error.labels(burrow.getCluster(), consumerGroup).inc();
+          metrics.error.labels(metricsCluster, consumerGroup).inc();
           workers.add(consumer);
         }
       }, this.executor);

--- a/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
+++ b/kafka_consumer_freshness_tracker/src/main/java/com/tesla/data/consumer/freshness/ConsumerFreshness.java
@@ -150,7 +150,7 @@ public class ConsumerFreshness {
               for (int i = 0; i < numConsumers; i++) {
                 queue.add(createConsumer(clusterConf));
               }
-              return new AbstractMap.SimpleEntry<>((String) clusterConf.get("name"), queue);
+              return new AbstractMap.SimpleEntry<>(burrowCluster(clusterConf), queue);
             }).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
     loadMetricsClusterLabels(conf);
 
@@ -161,18 +161,22 @@ public class ConsumerFreshness {
   void loadMetricsClusterLabels(Map<String, Object> conf) {
     this.metricsClusterByBurrowName = ((List<Map<String, Object>>) conf.get("clusters")).stream()
         .collect(Collectors.toMap(
-            clusterConf -> (String) clusterConf.get("name"),
-            this::metricsCluster));
+            this::burrowCluster,
+            clusterConf -> (String) clusterConf.get("name")));
   }
 
   /**
-   * Prometheus {@code cluster} label. Defaults to the Burrow cluster {@code name}.
+   * Burrow API cluster ({@code /v3/kafka/{name}}). Defaults to {@code clusters[].name}.
    */
-  private String metricsCluster(Map<String, Object> clusterConf) {
-    Object override = clusterConf.get("metricsClusterLabel");
+  private String burrowCluster(Map<String, Object> clusterConf) {
+    Object override = clusterConf.get("burrowClusterName");
     if (override instanceof String && !((String) override).isEmpty()) {
       return (String) override;
     }
+    return (String) clusterConf.get("name");
+  }
+
+  private String metricsCluster(Map<String, Object> clusterConf) {
     return (String) clusterConf.get("name");
   }
 
@@ -189,10 +193,10 @@ public class ConsumerFreshness {
    * @return a message describing the validation failure, if the config was invalid. Empty otherwise.
    */
   Optional<String> validateClusterConf(Map<String, Object> clusterConf) {
-    final String clusterName = (String) clusterConf.get("name");
+    final String burrowName = burrowCluster(clusterConf);
     final Set<String> bootstrapServersFromBurrow;
     try {
-      bootstrapServersFromBurrow = new HashSet<>(this.burrow.getClusterBootstrapServers(clusterName));
+      bootstrapServersFromBurrow = new HashSet<>(this.burrow.getClusterBootstrapServers(burrowName));
     } catch (IOException e) {
       this.metrics.burrowClusterDetailReadFailed.labels(metricsCluster(clusterConf)).inc();
       return Optional.of("failed to read cluster detail from Burrow: " + e.getMessage());

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/ConsumerFreshnessTest.java
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/ConsumerFreshnessTest.java
@@ -402,7 +402,7 @@ public class ConsumerFreshnessTest {
   }
 
   @Test
-  public void testMetricsClusterLabelFromClusterConfOverridesFreshnessLabel() throws Exception {
+  public void testBurrowClusterNameFromClusterConfKeepsMetricsName() throws Exception {
     Burrow burrow = mock(Burrow.class);
     String burrowName = "remote-burrow";
     String metricsCluster = "local-cluster";
@@ -412,8 +412,8 @@ public class ConsumerFreshnessTest {
         partitionState("topic1", 1, 10, 0));
     when(burrow.getClusters()).thenReturn(newArrayList(client));
 
-    Map<String, Object> clusterConf = mockConfForCluster(burrowName, "kafka.example.com:9092");
-    clusterConf.put("metricsClusterLabel", metricsCluster);
+    Map<String, Object> clusterConf = mockConfForCluster(metricsCluster, "kafka.example.com:9092");
+    clusterConf.put("burrowClusterName", burrowName);
     Map<String, Object> globalConf = new HashMap<>();
     globalConf.put("clusters", Lists.newArrayList(clusterConf));
 
@@ -425,7 +425,7 @@ public class ConsumerFreshnessTest {
       freshness.run();
 
       FreshnessMetrics metrics = freshness.getMetricsForTesting();
-      assertEquals("Freshness metrics use metricsClusterLabel, not the Burrow cluster name", 0,
+      assertEquals("Freshness metrics use name, not the Burrow cluster name", 0,
           metrics.freshness.labels(metricsCluster, "group1", "topic1", "1").get(), 0.0);
       assertSuccessfulClusterMeasurement(freshness, metricsCluster);
       try {
@@ -440,15 +440,15 @@ public class ConsumerFreshnessTest {
   }
 
   @Test
-  public void testEmptyMetricsClusterLabelFallsBackToBurrowName() throws Exception {
+  public void testEmptyBurrowClusterNameFallsBackToName() throws Exception {
     Burrow burrow = mock(Burrow.class);
-    String burrowName = "remote-burrow";
-    Burrow.ClusterClient client = mockClusterState(burrowName, "group1",
+    String clusterName = "local-cluster";
+    Burrow.ClusterClient client = mockClusterState(clusterName, "group1",
         partitionState("topic1", 1, 10, 0));
     when(burrow.getClusters()).thenReturn(newArrayList(client));
 
-    Map<String, Object> clusterConf = mockConfForCluster(burrowName, "kafka.example.com:9092");
-    clusterConf.put("metricsClusterLabel", "");
+    Map<String, Object> clusterConf = mockConfForCluster(clusterName, "kafka.example.com:9092");
+    clusterConf.put("burrowClusterName", "");
     Map<String, Object> globalConf = new HashMap<>();
     globalConf.put("clusters", Lists.newArrayList(clusterConf));
 
@@ -456,18 +456,18 @@ public class ConsumerFreshnessTest {
       KafkaConsumer consumer = mock(KafkaConsumer.class);
       ConsumerFreshness freshness = new ConsumerFreshness();
       freshness.loadMetricsClusterLabels(globalConf);
-      freshness.setupForTesting(burrow, workers(burrowName, consumer), executor);
+      freshness.setupForTesting(burrow, workers(clusterName, consumer), executor);
       freshness.run();
 
       FreshnessMetrics metrics = freshness.getMetricsForTesting();
-      assertEquals("Empty metricsClusterLabel keeps the Burrow cluster name", 0,
-          metrics.freshness.labels(burrowName, "group1", "topic1", "1").get(), 0.0);
-      assertSuccessfulClusterMeasurement(freshness, burrowName);
+      assertEquals("Empty burrowClusterName keeps name for metrics and Burrow", 0,
+          metrics.freshness.labels(clusterName, "group1", "topic1", "1").get(), 0.0);
+      assertSuccessfulClusterMeasurement(freshness, clusterName);
     });
   }
 
   @Test
-  public void testBurrowConsumerGroupReadFailureUsesMetricsClusterLabel() throws Exception {
+  public void testBurrowConsumerGroupReadFailureUsesName() throws Exception {
     Burrow burrow = mock(Burrow.class);
     String burrowName = "remote-burrow";
     String metricsCluster = "local-cluster";
@@ -475,8 +475,8 @@ public class ConsumerFreshnessTest {
     when(burrow.getClusters()).thenReturn(newArrayList(client));
     when(client.consumerGroups()).thenThrow(new IOException("injected"));
 
-    Map<String, Object> clusterConf = mockConfForCluster(burrowName, "kafka.example.com:9092");
-    clusterConf.put("metricsClusterLabel", metricsCluster);
+    Map<String, Object> clusterConf = mockConfForCluster(metricsCluster, "kafka.example.com:9092");
+    clusterConf.put("burrowClusterName", burrowName);
     Map<String, Object> globalConf = new HashMap<>();
     globalConf.put("clusters", Lists.newArrayList(clusterConf));
 
@@ -491,14 +491,14 @@ public class ConsumerFreshnessTest {
   }
 
   @Test
-  public void testBurrowClusterDetailReadFailedUsesMetricsClusterLabel() throws Exception {
+  public void testBurrowClusterDetailReadFailedUsesName() throws Exception {
     Burrow burrow = mock(Burrow.class);
     String burrowName = "remote-burrow";
     String metricsCluster = "local-cluster";
     when(burrow.getClusterBootstrapServers(burrowName)).thenThrow(new IOException("injected"));
 
-    Map<String, Object> conf = mockConfForCluster(burrowName, "kafka.example.com:9092");
-    conf.put("metricsClusterLabel", metricsCluster);
+    Map<String, Object> conf = mockConfForCluster(metricsCluster, "kafka.example.com:9092");
+    conf.put("burrowClusterName", burrowName);
 
     ConsumerFreshness freshness = new ConsumerFreshness();
     freshness.burrow = burrow;

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/ConsumerFreshnessTest.java
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/ConsumerFreshnessTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tesla.shade.com.google.common.collect.Lists.newArrayList;
@@ -400,19 +402,26 @@ public class ConsumerFreshnessTest {
   }
 
   @Test
-  public void testMetricsClusterOverridesFreshnessClusterLabel() throws Exception {
+  public void testMetricsClusterLabelFromClusterConfOverridesFreshnessLabel() throws Exception {
     Burrow burrow = mock(Burrow.class);
     String burrowName = "remote-burrow";
     String metricsCluster = "local-cluster";
+    when(burrow.getClusterBootstrapServers(burrowName))
+        .thenReturn(Arrays.asList("kafka.example.com:9092"));
     Burrow.ClusterClient client = mockClusterState(burrowName, "group1",
         partitionState("topic1", 1, 10, 0));
     when(burrow.getClusters()).thenReturn(newArrayList(client));
 
+    Map<String, Object> clusterConf = mockConfForCluster(burrowName, "kafka.example.com:9092");
+    clusterConf.put("metricsClusterLabel", metricsCluster);
+    Map<String, Object> globalConf = new HashMap<>();
+    globalConf.put("clusters", Lists.newArrayList(clusterConf));
+
     withExecutor(executor -> {
       KafkaConsumer consumer = mock(KafkaConsumer.class);
       ConsumerFreshness freshness = new ConsumerFreshness();
-      freshness.setupForTesting(burrow, workers(burrowName, consumer), executor,
-          ImmutableMap.of(burrowName, metricsCluster));
+      freshness.loadMetricsClusterLabels(globalConf);
+      freshness.setupForTesting(burrow, workers(burrowName, consumer), executor);
       freshness.run();
 
       FreshnessMetrics metrics = freshness.getMetricsForTesting();
@@ -420,6 +429,9 @@ public class ConsumerFreshnessTest {
           metrics.freshness.labels(metricsCluster, "group1", "topic1", "1").get(), 0.0);
       assertSuccessfulClusterMeasurement(freshness, metricsCluster);
       try {
+        freshness.validateClusterConf(clusterConf);
+        verify(burrow).getClusterBootstrapServers(burrowName);
+        verify(burrow, never()).getClusterBootstrapServers(metricsCluster);
         verifyNoInteractions(consumer);
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -428,18 +440,72 @@ public class ConsumerFreshnessTest {
   }
 
   @Test
-  public void testValidateClusterConfUsesNameForBurrow() throws Exception {
+  public void testEmptyMetricsClusterLabelFallsBackToBurrowName() throws Exception {
     Burrow burrow = mock(Burrow.class);
     String burrowName = "remote-burrow";
-    when(burrow.getClusterBootstrapServers(burrowName))
-        .thenReturn(Arrays.asList("kafka.example.com:9092"));
+    Burrow.ClusterClient client = mockClusterState(burrowName, "group1",
+        partitionState("topic1", 1, 10, 0));
+    when(burrow.getClusters()).thenReturn(newArrayList(client));
+
+    Map<String, Object> clusterConf = mockConfForCluster(burrowName, "kafka.example.com:9092");
+    clusterConf.put("metricsClusterLabel", "");
+    Map<String, Object> globalConf = new HashMap<>();
+    globalConf.put("clusters", Lists.newArrayList(clusterConf));
+
+    withExecutor(executor -> {
+      KafkaConsumer consumer = mock(KafkaConsumer.class);
+      ConsumerFreshness freshness = new ConsumerFreshness();
+      freshness.loadMetricsClusterLabels(globalConf);
+      freshness.setupForTesting(burrow, workers(burrowName, consumer), executor);
+      freshness.run();
+
+      FreshnessMetrics metrics = freshness.getMetricsForTesting();
+      assertEquals("Empty metricsClusterLabel keeps the Burrow cluster name", 0,
+          metrics.freshness.labels(burrowName, "group1", "topic1", "1").get(), 0.0);
+      assertSuccessfulClusterMeasurement(freshness, burrowName);
+    });
+  }
+
+  @Test
+  public void testBurrowConsumerGroupReadFailureUsesMetricsClusterLabel() throws Exception {
+    Burrow burrow = mock(Burrow.class);
+    String burrowName = "remote-burrow";
+    String metricsCluster = "local-cluster";
+    Burrow.ClusterClient client = mockClusterState(burrowName, "group1");
+    when(burrow.getClusters()).thenReturn(newArrayList(client));
+    when(client.consumerGroups()).thenThrow(new IOException("injected"));
+
+    Map<String, Object> clusterConf = mockConfForCluster(burrowName, "kafka.example.com:9092");
+    clusterConf.put("metricsClusterLabel", metricsCluster);
+    Map<String, Object> globalConf = new HashMap<>();
+    globalConf.put("clusters", Lists.newArrayList(clusterConf));
+
+    ConsumerFreshness freshness = new ConsumerFreshness();
+    freshness.loadMetricsClusterLabels(globalConf);
+    freshness.setupForTesting(burrow, workers(burrowName), null);
+    freshness.run();
+    assertEquals(1.0,
+        freshness.getMetricsForTesting().burrowClustersConsumersReadFailed.labels(metricsCluster).get(),
+        0.0);
+    assertNoSuccessfulClusterMeasurement(freshness, metricsCluster);
+  }
+
+  @Test
+  public void testBurrowClusterDetailReadFailedUsesMetricsClusterLabel() throws Exception {
+    Burrow burrow = mock(Burrow.class);
+    String burrowName = "remote-burrow";
+    String metricsCluster = "local-cluster";
+    when(burrow.getClusterBootstrapServers(burrowName)).thenThrow(new IOException("injected"));
 
     Map<String, Object> conf = mockConfForCluster(burrowName, "kafka.example.com:9092");
-    conf.put("metricsClusterLabel", "local-cluster");
+    conf.put("metricsClusterLabel", metricsCluster);
 
     ConsumerFreshness freshness = new ConsumerFreshness();
     freshness.burrow = burrow;
-    Assert.assertFalse(freshness.validateClusterConf(conf).isPresent());
+    Assert.assertTrue(freshness.validateClusterConf(conf).isPresent());
+    Assert.assertEquals(1.0,
+        freshness.getMetricsForTesting().burrowClusterDetailReadFailed.labels(metricsCluster).get(),
+        0.0);
   }
 
   Map<String, Object> mockConfForCluster(String name, String... bootstrapServers) {

--- a/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/ConsumerFreshnessTest.java
+++ b/kafka_consumer_freshness_tracker/src/test/java/com/tesla/data/consumer/freshness/ConsumerFreshnessTest.java
@@ -399,6 +399,49 @@ public class ConsumerFreshnessTest {
     freshness.setupWithBurrow(globalConf, burrow);
   }
 
+  @Test
+  public void testMetricsClusterOverridesFreshnessClusterLabel() throws Exception {
+    Burrow burrow = mock(Burrow.class);
+    String burrowName = "remote-burrow";
+    String metricsCluster = "local-cluster";
+    Burrow.ClusterClient client = mockClusterState(burrowName, "group1",
+        partitionState("topic1", 1, 10, 0));
+    when(burrow.getClusters()).thenReturn(newArrayList(client));
+
+    withExecutor(executor -> {
+      KafkaConsumer consumer = mock(KafkaConsumer.class);
+      ConsumerFreshness freshness = new ConsumerFreshness();
+      freshness.setupForTesting(burrow, workers(burrowName, consumer), executor,
+          ImmutableMap.of(burrowName, metricsCluster));
+      freshness.run();
+
+      FreshnessMetrics metrics = freshness.getMetricsForTesting();
+      assertEquals("Freshness metrics use metricsClusterLabel, not the Burrow cluster name", 0,
+          metrics.freshness.labels(metricsCluster, "group1", "topic1", "1").get(), 0.0);
+      assertSuccessfulClusterMeasurement(freshness, metricsCluster);
+      try {
+        verifyNoInteractions(consumer);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @Test
+  public void testValidateClusterConfUsesNameForBurrow() throws Exception {
+    Burrow burrow = mock(Burrow.class);
+    String burrowName = "remote-burrow";
+    when(burrow.getClusterBootstrapServers(burrowName))
+        .thenReturn(Arrays.asList("kafka.example.com:9092"));
+
+    Map<String, Object> conf = mockConfForCluster(burrowName, "kafka.example.com:9092");
+    conf.put("metricsClusterLabel", "local-cluster");
+
+    ConsumerFreshness freshness = new ConsumerFreshness();
+    freshness.burrow = burrow;
+    Assert.assertFalse(freshness.validateClusterConf(conf).isPresent());
+  }
+
   Map<String, Object> mockConfForCluster(String name, String... bootstrapServers) {
     Map<String, Object> clusterConf = new HashMap<>();
     Map<String, Object> kafkaConf = new HashMap<>();


### PR DESCRIPTION
## Summary
- `clusters[].name` is the Prometheus `cluster` label.
- Optional `burrowClusterName` is the Burrow API cluster (`/v3/kafka/{name}`) when it differs.
- If `burrowClusterName` is omitted or empty, Burrow uses `name`.
- Worker lookup, bootstrap validation, and skip logs still key on the Burrow name.

This change is a no-op until a config sets `burrowClusterName`. Existing configs that only set `name` keep the same Burrow path and the same metrics label.

## Test plan
- [x] `ConsumerFreshnessTest` (Burrow override from cluster conf, empty-string fallback, metrics use `name`, failed consumer-groups and cluster-detail reads use `name`)
- [x] Existing `BurrowTest` and `FreshnessTrackerTest` still pass